### PR TITLE
Change default port to 10101

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -250,7 +250,7 @@ func TestInvalidResponse(t *testing.T) {
 }
 
 func getClient() *Client {
-	uri, err := NewURIFromAddress("localhost:15000")
+	uri, err := NewURIFromAddress(":10101")
 	if err != nil {
 		panic(err)
 	}

--- a/uri.go
+++ b/uri.go
@@ -22,7 +22,7 @@ func NewURI() *URI {
 	return &URI{
 		scheme: "http",
 		host:   "localhost",
-		port:   15000,
+		port:   10101,
 	}
 }
 
@@ -87,7 +87,7 @@ func parseAddress(address string) (uri *URI, err error) {
 	if m[3] != "" {
 		host = m[3]
 	}
-	var port = 15000
+	var port = 10101
 	if m[5] != "" {
 		port, _ = strconv.Atoi(m[5])
 	}

--- a/uri_test.go
+++ b/uri_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestDefaultURI(t *testing.T) {
 	uri := NewURI()
-	compare(t, uri, "http", "localhost", 15000)
+	compare(t, uri, "http", "localhost", 10101)
 }
 
 func TestURIWithHostPort(t *testing.T) {
@@ -23,8 +23,8 @@ func TestURIFromAddress(t *testing.T) {
 	}{
 		{"http+protobuf://db1.pilosa.com:3333", "http+protobuf", "db1.pilosa.com", 3333},
 		{"db1.pilosa.com:3333", "http", "db1.pilosa.com", 3333},
-		{"https://db1.pilosa.com", "https", "db1.pilosa.com", 15000},
-		{"db1.pilosa.com", "http", "db1.pilosa.com", 15000},
+		{"https://db1.pilosa.com", "https", "db1.pilosa.com", 10101},
+		{"db1.pilosa.com", "http", "db1.pilosa.com", 10101},
 		{"https://:3333", "https", "localhost", 3333},
 		{":3333", "http", "localhost", 3333},
 	}


### PR DESCRIPTION
```
$ go test -cover -tags=integration
PASS
coverage: 100.0% of statements
ok  	github.com/pilosa/go-client-pilosa	0.990s
```