### PR TITLE
fixed issue with requiring an (optional) bitmap for TopN call

### DIFF
--- a/orm.go
+++ b/orm.go
@@ -542,7 +542,11 @@ func (f *Frame) filterFieldTopN(n uint64, bitmap *PQLBitmapQuery, inverse bool, 
 	if !inverse {
 		inverseStr = "false"
 	}
-	return NewPQLBitmapQuery(fmt.Sprintf("TopN(%s, frame='%s', n=%d, inverse=%s, field='%s', %s)",
+	if bitmap == nil {
+		return NewPQLBitmapQuery(fmt.Sprintf("TopN(frame='%s', n=%d, inverse=%s, field='%s', filters=%s)",
+			f.name, n, inverseStr, field, string(b)), f.index, nil)
+	}
+	return NewPQLBitmapQuery(fmt.Sprintf("TopN(%s, frame='%s', n=%d, inverse=%s, field='%s', filters=%s)",
 		bitmap.serialize(), f.name, n, inverseStr, field, string(b)), f.index, nil)
 }
 

--- a/orm_test.go
+++ b/orm_test.go
@@ -303,11 +303,14 @@ func TestTopN(t *testing.T) {
 		"TopN(Bitmap(project=3, frame='collaboration'), frame='sample-frame', n=10, inverse=true)",
 		sampleFrame.InverseBitmapTopN(10, collabFrame.Bitmap(3)))
 	comparePQL(t,
-		"TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=false, field='category', [80,81])",
+		"TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=false, field='category', filters=[80,81])",
 		sampleFrame.FilterFieldTopN(12, collabFrame.Bitmap(7), "category", 80, 81))
 	comparePQL(t,
-		"TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=true, field='category', [80,81])",
+		"TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=true, field='category', filters=[80,81])",
 		sampleFrame.InverseFilterFieldTopN(12, collabFrame.Bitmap(7), "category", 80, 81))
+	comparePQL(t,
+		"TopN(frame='sample-frame', n=12, inverse=true, field='category', filters=[80,81])",
+		sampleFrame.InverseFilterFieldTopN(12, nil, "category", 80, 81))	
 }
 
 func TestFilterFieldTopNInvalidField(t *testing.T) {

--- a/orm_test.go
+++ b/orm_test.go
@@ -310,7 +310,7 @@ func TestTopN(t *testing.T) {
 		sampleFrame.InverseFilterFieldTopN(12, collabFrame.Bitmap(7), "category", 80, 81))
 	comparePQL(t,
 		"TopN(frame='sample-frame', n=12, inverse=true, field='category', filters=[80,81])",
-		sampleFrame.InverseFilterFieldTopN(12, nil, "category", 80, 81))	
+		sampleFrame.InverseFilterFieldTopN(12, nil, "category", 80, 81))
 }
 
 func TestFilterFieldTopNInvalidField(t *testing.T) {


### PR DESCRIPTION
As well as adding the field name `filters` to the `TopN` call when arguments are given in the `FilterFieldTopN` call, per [the query language docs](https://www.pilosa.com/docs/query-language/).  Otherwise this error occurs:

```
Error: expected argument key, found "[" occurred at line 1, char 62
```

Updated tests for both fixes.