### PR TITLE
Response defaults + Custom time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Go client for Pilosa high performance distributed bitmap index.
     * Added support for creating range encoded frames.
     * Added `SetFieldValue`, `Sum` and `Xor` calls.
     * Added support for excluding bits or attributes from bitmap calls. In order to exclude bits, pass `ExcludeBits: true` in your `QueryOptions`. In order to exclude attributes, pass `ExcludeAttrs: true`.
+    * Customizable CSV time stamp format.
 
 * **v0.5.0** (2017-08-03):
     * Supports imports and exports.

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -116,6 +116,40 @@ func TestClientReturnsResponse(t *testing.T) {
 	}
 }
 
+func TestResponseDefaults(t *testing.T) {
+	assertResult := func(r *QueryResult) {
+		if r.Bitmap == nil {
+			t.Fatalf("Default should be set for bitmap result")
+		}
+		if r.CountItems == nil {
+			t.Fatalf("CountItems should be set for bitmap result")
+		}
+	}
+
+	client := getClient()
+
+	frame, _ := index.Frame("defaults-frame", nil)
+	err := client.CreateFrame(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := client.Query(frame.TopN(5), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := response.Result()
+	assertResult(result)
+
+	response, err = client.Query(frame.Bitmap(99999), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result = response.Result()
+	assertResult(result)
+
+}
+
 func TestQueryWithColumns(t *testing.T) {
 	Reset()
 	client := getClient()

--- a/response.go
+++ b/response.go
@@ -122,6 +122,8 @@ func newQueryResultFromInternal(result *internal.QueryResult) (*QueryResult, err
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		bitmapResult = &BitmapResult{}
 	}
 	if result.SumCount != nil {
 		sum = result.SumCount.Sum


### PR DESCRIPTION
The tests run fine locally against a custom built pilosa server with `field-value-import` branch. The CI build will fail.