### PR TITLE
error handling and single http client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,9 +7,15 @@
   packages = ["proto"]
   revision = "888eb0692c857ec880338addf316bd662d5e630e"
 
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "99ae9a8db8c1345b9acbd75c1585531f802b79692c95b37f31ad73dc6c47b337"
+  inputs-digest = "6c664b4e7ef95e3c205dfe2258ebaec3838f5b8bb19a44f5f89903269ce2fa67"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: test
 
 cover:
-	go test -cover -tags=integration -coverprofile=coverage.out
+	go test -cover -tags=integration
 
 generate:
 	protoc --go_out=. internal/public.proto

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: test
 
 cover:
-	go test -cover -tags=integration
+	go test -cover -tags=integration -coverprofile=coverage.out
 
 generate:
 	protoc --go_out=. internal/public.proto

--- a/client.go
+++ b/client.go
@@ -475,12 +475,12 @@ func (c *Client) patchFrameTimeQuantum(frame *Frame) error {
 func (c *Client) status() (*Status, error) {
 	_, data, err := c.httpRequest("GET", "/status", nil, nil, errorCheckedResponse)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "requesting /status")
 	}
 	root := &statusRoot{}
 	err = json.Unmarshal(data, root)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unmarshaling /status data")
 	}
 	return root.Status, nil
 }

--- a/client.go
+++ b/client.go
@@ -59,10 +59,8 @@ var protobufHeaders = map[string]string{
 
 // Client is the HTTP client for Pilosa server.
 type Client struct {
-	cluster      *Cluster
-	host         *URI
-	client       *http.Client
-	cacheClients map[string]*Client
+	cluster *Cluster
+	client  *http.Client
 }
 
 // DefaultClient creates a client with the default address and options.
@@ -99,9 +97,8 @@ func NewClientWithCluster(cluster *Cluster, options *ClientOptions) *Client {
 		options = &ClientOptions{}
 	}
 	return &Client{
-		cluster:      cluster,
-		client:       newHTTPClient(options.withDefaults()),
-		cacheClients: make(map[string]*Client),
+		cluster: cluster,
+		client:  newHTTPClient(options.withDefaults()),
 	}
 }
 
@@ -358,22 +355,6 @@ func (c *Client) ImportValueFrame(frame *Frame, field string, valueIterator Valu
 	return nil
 }
 
-func (c *Client) getDirectClient(host string) (*Client, error) {
-	key := host
-	client, ok := c.cacheClients[key]
-	if ok {
-		return client, nil
-	}
-	uri, err := NewURIFromAddress(host)
-	if err != nil {
-		return nil, err
-	}
-	client = NewClientWithURI(uri)
-
-	c.cacheClients[key] = client
-	return client, nil
-}
-
 func (c *Client) importBits(indexName string, frameName string, slice uint64, bits []Bit) error {
 	sort.Sort(bitsForSort(bits))
 	nodes, err := c.fetchFragmentNodes(indexName, slice)
@@ -381,12 +362,11 @@ func (c *Client) importBits(indexName string, frameName string, slice uint64, bi
 		return err
 	}
 	for _, node := range nodes {
-		client, err := c.getDirectClient(node.Host)
+		uri, err := NewURIFromAddress(node.Host)
 		if err != nil {
 			return err
 		}
-
-		err = client.importNode(bitsToImportRequest(indexName, frameName, slice, bits))
+		err = c.importNode(uri, bitsToImportRequest(indexName, frameName, slice, bits))
 		if err != nil {
 			return err
 		}
@@ -402,12 +382,11 @@ func (c *Client) importValues(indexName string, frameName string, slice uint64, 
 		return err
 	}
 	for _, node := range nodes {
-		client, err := c.getDirectClient(node.Host)
+		uri, err := NewURIFromAddress(node.Host)
 		if err != nil {
 			return err
 		}
-
-		err = client.importValueNode(valsToImportRequest(indexName, frameName, slice, fieldName, vals))
+		err = c.importValueNode(uri, valsToImportRequest(indexName, frameName, slice, fieldName, vals))
 		if err != nil {
 			return err
 		}
@@ -430,26 +409,24 @@ func (c *Client) fetchFragmentNodes(indexName string, slice uint64) ([]fragmentN
 	return fragmentNodes, nil
 }
 
-func (c *Client) importNode(request *internal.ImportRequest) error {
+func (c *Client) importNode(uri *URI, request *internal.ImportRequest) error {
 	data, err := proto.Marshal(request)
 	if err != nil {
 		return errors.Wrap(err, "marshaling to protobuf")
 	}
-	// request.Marshal never returns an error
-	_, _, err = c.httpRequest("POST", "/import", data, protobufHeaders, noResponse)
-	if err != nil {
-		return err
+	resp, err := c.doRequest(uri, "POST", "/import", protobufHeaders, bytes.NewReader(data))
+	if err = anyError(resp, err); err != nil {
+		return errors.Wrap(err, "doing import request")
 	}
-
-	return nil
+	return errors.Wrap(resp.Body.Close(), "closing import response body")
 }
 
-func (c *Client) importValueNode(request *internal.ImportValueRequest) error {
+func (c *Client) importValueNode(uri *URI, request *internal.ImportValueRequest) error {
 	data, _ := proto.Marshal(request)
 	// request.Marshal never returns an error
-	_, _, err := c.httpRequest("POST", "/import-value", data, protobufHeaders, noResponse)
+	_, err := c.doRequest(uri, "POST", "/import-value", protobufHeaders, bytes.NewReader(data))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "doing /import-value request")
 	}
 
 	return nil
@@ -462,7 +439,7 @@ func (c *Client) ExportFrame(frame *Frame, view string) (BitIterator, error) {
 		return nil, err
 	}
 	sliceURIs := statusToNodeSlicesForIndex(status, frame.index.Name())
-	return NewCSVBitIterator(newExportReader(sliceURIs, frame, view)), nil
+	return NewCSVBitIterator(newExportReader(c, sliceURIs, frame, view)), nil
 }
 
 // Views fetches and returns the views of a frame
@@ -508,32 +485,30 @@ func (c *Client) status() (*Status, error) {
 	return root.Status, nil
 }
 
+// httpRequest makes a request to the cluster - use this when you want the
+// client to choose a host, and it doesn't matter if the request goes to a
+// specific host
 func (c *Client) httpRequest(method string, path string, data []byte, headers map[string]string, returnResponse returnClientInfo) (*http.Response, []byte, error) {
 	if data == nil {
 		data = []byte{}
 	}
-	reader := bytes.NewReader(data)
 
 	// try at most maxHosts non-failed hosts; protect against broken cluster.removeHost
 	var response *http.Response
 	var err error
 	for i := 0; i < maxHosts; i++ {
-		if c.host == nil {
-			c.host = c.cluster.Host()
-			if c.host == nil {
-				return nil, nil, ErrorEmptyCluster
-			}
+		reader := bytes.NewReader(data)
+		// get a host from the cluster
+		host := c.cluster.Host()
+		if host == nil {
+			return nil, nil, ErrorEmptyCluster
 		}
-		request, err := c.makeRequest(method, path, headers, reader)
-		if err != nil {
-			return nil, nil, err
-		}
-		response, err = c.client.Do(request)
+
+		response, err = c.doRequest(host, method, path, headers, reader)
 		if err == nil {
 			break
 		}
-		c.cluster.RemoveHost(c.host)
-		c.host = c.cluster.Host()
+		c.cluster.RemoveHost(host)
 	}
 	if response == nil {
 		return nil, nil, ErrorTriedMaxHosts
@@ -561,8 +536,40 @@ func (c *Client) httpRequest(method string, path string, data []byte, headers ma
 	return response, buf, nil
 }
 
-func (c *Client) makeRequest(method string, path string, headers map[string]string, reader io.Reader) (*http.Request, error) {
-	request, err := http.NewRequest(method, c.host.Normalize()+path, reader)
+// anyError checks an http Response and error to see if anything went wrong with
+// a request (either locally, or on the server) and returns a single error if
+// so.
+func anyError(resp *http.Response, err error) error {
+	if err != nil {
+		return errors.Wrap(err, "unable to perform request")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		buf, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "bad status '%s' and err reading body", resp.Status)
+		}
+		msg := string(buf)
+		err = matchError(msg)
+		if err != nil {
+			return err
+		}
+		return errors.Errorf("Server error %s body:'%s'", resp.Status, msg)
+	}
+	return nil
+}
+
+// doRequest creates and performs an http request.
+func (c *Client) doRequest(host *URI, method, path string, headers map[string]string, reader io.Reader) (*http.Response, error) {
+	req, err := makeRequest(host, method, path, headers, reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "building request")
+	}
+	return c.client.Do(req)
+}
+
+func makeRequest(host *URI, method, path string, headers map[string]string, reader io.Reader) (*http.Request, error) {
+	request, err := http.NewRequest(method, host.Normalize()+path, reader)
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +578,7 @@ func (c *Client) makeRequest(method string, path string, headers map[string]stri
 		request.Header.Set(k, v)
 	}
 
-	return request, err
+	return request, nil
 }
 
 func newHTTPClient(options *ClientOptions) *http.Client {
@@ -683,10 +690,10 @@ func (options *ClientOptions) withDefaults() (updated *ClientOptions) {
 	*updated = *options
 	// impose defaults
 	if updated.SocketTimeout <= 0 {
-		updated.SocketTimeout = time.Second * 300
+		updated.SocketTimeout = time.Second * 10000
 	}
 	if updated.ConnectTimeout <= 0 {
-		updated.ConnectTimeout = time.Second * 30
+		updated.ConnectTimeout = time.Second * 60
 	}
 	if updated.PoolSizePerRoute <= 0 {
 		updated.PoolSizePerRoute = 10
@@ -764,6 +771,7 @@ type viewsInfo struct {
 }
 
 type exportReader struct {
+	client       *Client
 	sliceURIs    map[uint64]*URI
 	frame        *Frame
 	body         []byte
@@ -773,8 +781,9 @@ type exportReader struct {
 	view         string
 }
 
-func newExportReader(sliceURIs map[uint64]*URI, frame *Frame, view string) *exportReader {
+func newExportReader(client *Client, sliceURIs map[uint64]*URI, frame *Frame, view string) *exportReader {
 	return &exportReader{
+		client:     client,
 		sliceURIs:  sliceURIs,
 		frame:      frame,
 		sliceCount: uint64(len(sliceURIs)),
@@ -793,12 +802,16 @@ func (r *exportReader) Read(p []byte) (n int, err error) {
 		headers := map[string]string{
 			"Accept": "text/csv",
 		}
-		client := NewClientWithURI(uri)
 		path := fmt.Sprintf("/export?index=%s&frame=%s&slice=%d&view=%s",
 			r.frame.index.Name(), r.frame.Name(), r.currentSlice, r.view)
-		_, r.body, err = client.httpRequest("GET", path, nil, headers, errorCheckedResponse)
+		resp, err := r.client.doRequest(uri, "GET", path, headers, nil)
+		if err = anyError(resp, err); err != nil {
+			return 0, errors.Wrap(err, "doing export request")
+		}
+		defer resp.Body.Close()
+		r.body, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return
+			return 0, errors.Wrap(err, "reading response body")
 		}
 		r.bodyIndex = 0
 	}

--- a/client.go
+++ b/client.go
@@ -690,7 +690,7 @@ func (options *ClientOptions) withDefaults() (updated *ClientOptions) {
 	*updated = *options
 	// impose defaults
 	if updated.SocketTimeout <= 0 {
-		updated.SocketTimeout = time.Second * 10000
+		updated.SocketTimeout = time.Second * 300
 	}
 	if updated.ConnectTimeout <= 0 {
 		updated.ConnectTimeout = time.Second * 60

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -36,3 +36,20 @@ func TestNewClientFromAddresses(t *testing.T) {
 		t.Fatalf("Got error when creating empty client from addresses: %v", err)
 	}
 }
+
+func TestMakeRequestData(t *testing.T) {
+	q := make([]byte, 2<<30)
+	q[0] = 'a'
+	p := PQLBaseQuery{
+		pql: string(q),
+	}
+	uri, err := NewURIFromAddress("localhost:10101")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := NewClientWithURI(uri)
+	resp, err := cli.Query(&p, nil)
+	if err == nil {
+		t.Fatalf("expected err with too large query, but got %v", resp)
+	}
+}

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -1228,24 +1228,6 @@ func TestStatusToNodeSlicesForIndex(t *testing.T) {
 	}
 }
 
-func TestClientCache(t *testing.T) {
-	// even though this function isn't really an integration test,
-	// it needs to access getDirectClient which is not
-	// available to client_test.go
-	client := DefaultClient()
-	client2, err := client.getDirectClient("foo.bar:10101")
-	if err != nil {
-		t.Fatal(err)
-	}
-	client3, err := client.getDirectClient("foo.bar:10101")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if client2 != client3 {
-		t.Fatal("Should return the same client for the same host")
-	}
-}
-
 func getClient() *Client {
 	uri, err := NewURIFromAddress(":10101")
 	if err != nil {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -808,7 +808,8 @@ func TestExportReaderFailure(t *testing.T) {
 	sliceURIs := map[uint64]*URI{
 		0: uri,
 	}
-	reader := newExportReader(sliceURIs, frame, "standard")
+	client := NewClientWithURI(uri)
+	reader := newExportReader(client, sliceURIs, frame, "standard")
 	buf := make([]byte, 1000)
 	_, err = reader.Read(buf)
 	if err == nil {
@@ -1094,7 +1095,7 @@ func TestImportNodeFails(t *testing.T) {
 		Frame:      "bar",
 		Slice:      0,
 	}
-	err = client.importNode(importRequest)
+	err = client.importNode(uri, importRequest)
 	if err == nil {
 		t.Fatalf("importNode should fail when posting to /import fails")
 	}

--- a/uri.go
+++ b/uri.go
@@ -33,11 +33,12 @@
 package pilosa
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 var addressRegexp = regexp.MustCompile("^(([+a-z]+):\\/\\/)?([0-9a-z.-]+)?(:([0-9]+))?$")
@@ -135,12 +136,15 @@ func parseAddress(address string) (uri *URI, err error) {
 	}
 	var port = 10101
 	if m[5] != "" {
-		port, _ = strconv.Atoi(m[5])
+		port, err = strconv.Atoi(m[5])
+		if err != nil {
+			return nil, errors.Wrap(err, "converting port string to int")
+		}
 	}
 	uri = &URI{
 		scheme: scheme,
 		host:   host,
 		port:   uint16(port),
 	}
-	return
+	return uri, nil
 }

--- a/uri_test.go
+++ b/uri_test.go
@@ -32,9 +32,7 @@
 
 package pilosa
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestDefaultURI(t *testing.T) {
 	uri := DefaultURI()
@@ -76,7 +74,7 @@ func TestURIFromAddress(t *testing.T) {
 func TestInvalidAddress(t *testing.T) {
 	var uri *URI
 	var err error
-	addresses := []string{"foo:bar", "http://foo:", "foo:", ":bar"}
+	addresses := []string{"foo:bar", "http://foo:", "foo:", ":bar", "http://pilosa.com:129999999999999999999999993"}
 	for _, addr := range addresses {
 		uri, err = NewURIFromAddress(addr)
 		if uri != nil || err == nil {


### PR DESCRIPTION
this combines a bunch of error handling, and making pilosa.Client only use a single http.Client object. It greatly simplifies pilosa.Client and makes cluster.Host the chief determiner of which host in the cluster should be queried (for queries where a specific host is not specified).