### PR TITLE
Mass update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key &
   - go get github.com/mattn/goveralls
   - go get -u github.com/golang/dep/cmd/dep
+  - sleep 10
 addons:
 script:
   - dep ensure

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - openssl req -x509 -newkey rsa:4096 -keyout test.pilosa.local.key -out test.pilosa.local.crt -days 3650 -nodes -subj "/C=US/ST=Texas/L=Austin/O=Pilosa/OU=Com/CN=test.pilosa.local"
   - wget https://s3.amazonaws.com/build.pilosa.com/pilosa-master-linux-amd64.tar.gz && tar xf pilosa-master-linux-amd64.tar.gz
   - ./pilosa-master-linux-amd64/pilosa server -d http_data &
-  - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key --gossip.port 16000 &
+  - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key --cluster.type static &
   - go get github.com/mattn/goveralls
   - go get -u github.com/golang/dep/cmd/dep
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ go:
 sudo: required
 group: deprecated-2017Q2
 before_install:
+  - openssl req -x509 -newkey rsa:4096 -keyout test.pilosa.local.key -out test.pilosa.local.crt -days 3650 -nodes -subj "/C=US/ST=Texas/L=Austin/O=Pilosa/OU=Com/CN=test.pilosa.local"
   - wget https://s3.amazonaws.com/build.pilosa.com/pilosa-master-linux-amd64.tar.gz && tar xf pilosa-master-linux-amd64.tar.gz
-  - ./pilosa-master-linux-amd64/pilosa server &
+  - ./pilosa-master-linux-amd64/pilosa server -d http_data &
+  - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key &
   - go get github.com/mattn/goveralls
   - go get -u github.com/golang/dep/cmd/dep
 addons:
 script:
-  - dep ensure && $HOME/gopath/bin/goveralls -service=travis-ci -ignore "gopilosa_pbuf/public.pb.go" -flags="-tags=integration fullcoverage"
+  - dep ensure
+  - PILOSA_BIND="https://:20101" make test-all
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore "gopilosa_pbuf/public.pb.go" -flags="-tags=integration fullcoverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ before_install:
   - openssl req -x509 -newkey rsa:4096 -keyout test.pilosa.local.key -out test.pilosa.local.crt -days 3650 -nodes -subj "/C=US/ST=Texas/L=Austin/O=Pilosa/OU=Com/CN=test.pilosa.local"
   - wget https://s3.amazonaws.com/build.pilosa.com/pilosa-master-linux-amd64.tar.gz && tar xf pilosa-master-linux-amd64.tar.gz
   - ./pilosa-master-linux-amd64/pilosa server -d http_data &
-  - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key &
+  - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key --gossip.port 16000 &
   - go get github.com/mattn/goveralls
   - go get -u github.com/golang/dep/cmd/dep
-  - sleep 10
 addons:
 script:
   - dep ensure

--- a/client.go
+++ b/client.go
@@ -518,8 +518,8 @@ func (c *Client) status() (*Status, error) {
 	return root.Status, nil
 }
 
-// HttpGet sends a GET request to the Pilosa server
-// **NOTE**: this function is experim
+// HttpGet sends a GET request to the Pilosa server.
+// **NOTE**: This function is experimental and may be removed in later revisions.
 func (c *Client) HttpGet(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
 	if path == "" {
 		return nil, nil, errors.New("Path is required for GET request")
@@ -527,7 +527,8 @@ func (c *Client) HttpGet(path string, data []byte, headers map[string]string) (*
 	return c.httpRequest("GET", path, data, headers, errorCheckedResponse)
 }
 
-// HttpPost sends a POST request to the Pilosa server
+// HttpPost sends a POST request to the Pilosa server.
+// **NOTE**: This function is experimental and may be removed in later revisions.
 func (c *Client) HttpPost(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
 	if path == "" {
 		return nil, nil, errors.New("Path is required for POST request")
@@ -535,7 +536,8 @@ func (c *Client) HttpPost(path string, data []byte, headers map[string]string) (
 	return c.httpRequest("POST", path, data, headers, errorCheckedResponse)
 }
 
-// HttpDelete sends a DELETE request to the Pilosa server
+// HttpDelete sends a DELETE request to the Pilosa server.
+// **NOTE**: This function is experimental and may be removed in later revisions.
 func (c *Client) HttpDelete(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
 	if path == "" {
 		return nil, nil, errors.New("Path is required for DELETE request")

--- a/client.go
+++ b/client.go
@@ -518,37 +518,19 @@ func (c *Client) status() (*Status, error) {
 	return root.Status, nil
 }
 
-// HttpGet sends a GET request to the Pilosa server.
+// HttpGet sends an HTTP request to the Pilosa server.
 // **NOTE**: This function is experimental and may be removed in later revisions.
-func (c *Client) HttpGet(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
-	if path == "" {
-		return nil, nil, errors.New("Path is required for GET request")
-	}
-	return c.httpRequest("GET", path, data, headers, errorCheckedResponse)
-}
-
-// HttpPost sends a POST request to the Pilosa server.
-// **NOTE**: This function is experimental and may be removed in later revisions.
-func (c *Client) HttpPost(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
-	if path == "" {
-		return nil, nil, errors.New("Path is required for POST request")
-	}
-	return c.httpRequest("POST", path, data, headers, errorCheckedResponse)
-}
-
-// HttpDelete sends a DELETE request to the Pilosa server.
-// **NOTE**: This function is experimental and may be removed in later revisions.
-func (c *Client) HttpDelete(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
-	if path == "" {
-		return nil, nil, errors.New("Path is required for DELETE request")
-	}
-	return c.httpRequest("DELETE", path, data, headers, errorCheckedResponse)
+func (c *Client) HttpRequest(method string, path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
+	return c.httpRequest(method, path, data, headers, rawResponse)
 }
 
 // httpRequest makes a request to the cluster - use this when you want the
 // client to choose a host, and it doesn't matter if the request goes to a
 // specific host
 func (c *Client) httpRequest(method string, path string, data []byte, headers map[string]string, returnResponse returnClientInfo) (*http.Response, []byte, error) {
+	if path == "" {
+		return nil, nil, errors.New("Path is required for HTTP request")
+	}
 	if data == nil {
 		data = []byte{}
 	}

--- a/client.go
+++ b/client.go
@@ -630,9 +630,6 @@ func (c *Client) doRequest(host *URI, method, path string, headers map[string]st
 
 // statusToNodeSlicesForIndex finds the hosts which contains slices for the given index
 func (c *Client) statusToNodeSlicesForIndex(status *Status, indexName string) map[uint64]*URI {
-	// /status endpoint doesn't return the node scheme yet, default to the scheme of the current URI
-	// TODO: remove the following when /status endpoint returns the scheme for nodes
-	scheme := c.cluster.hosts[0].Scheme()
 	result := make(map[uint64]*URI)
 	for _, node := range status.Nodes {
 		for _, index := range node.Indexes {
@@ -643,7 +640,7 @@ func (c *Client) statusToNodeSlicesForIndex(status *Status, indexName string) ma
 				uri, err := NewURIFromAddress(node.Host)
 				// err will always be nil, but prevent a panic in the odd chance the server returns an invalid URI
 				if err == nil {
-					uri.SetScheme(scheme)
+					uri.SetScheme(node.Scheme)
 					result[slice] = uri
 				}
 			}

--- a/client.go
+++ b/client.go
@@ -528,9 +528,6 @@ func (c *Client) HttpRequest(method string, path string, data []byte, headers ma
 // client to choose a host, and it doesn't matter if the request goes to a
 // specific host
 func (c *Client) httpRequest(method string, path string, data []byte, headers map[string]string, returnResponse returnClientInfo) (*http.Response, []byte, error) {
-	if path == "" {
-		return nil, nil, errors.New("Path is required for HTTP request")
-	}
 	if data == nil {
 		data = []byte{}
 	}

--- a/client.go
+++ b/client.go
@@ -518,6 +518,31 @@ func (c *Client) status() (*Status, error) {
 	return root.Status, nil
 }
 
+// HttpGet sends a GET request to the Pilosa server
+// **NOTE**: this function is experim
+func (c *Client) HttpGet(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
+	if path == "" {
+		return nil, nil, errors.New("Path is required for GET request")
+	}
+	return c.httpRequest("GET", path, data, headers, errorCheckedResponse)
+}
+
+// HttpPost sends a POST request to the Pilosa server
+func (c *Client) HttpPost(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
+	if path == "" {
+		return nil, nil, errors.New("Path is required for POST request")
+	}
+	return c.httpRequest("POST", path, data, headers, errorCheckedResponse)
+}
+
+// HttpDelete sends a DELETE request to the Pilosa server
+func (c *Client) HttpDelete(path string, data []byte, headers map[string]string) (*http.Response, []byte, error) {
+	if path == "" {
+		return nil, nil, errors.New("Path is required for DELETE request")
+	}
+	return c.httpRequest("DELETE", path, data, headers, errorCheckedResponse)
+}
+
 // httpRequest makes a request to the cluster - use this when you want the
 // client to choose a host, and it doesn't matter if the request goes to a
 // specific host

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -1378,16 +1378,6 @@ func TestHttpRequest(t *testing.T) {
 	}
 }
 
-func TestHttpRequestWithoutPathFails(t *testing.T) {
-	client := getClient()
-	data := []byte("some data")
-	headers := map[string]string{"Foo": "Bar"}
-	_, _, err := client.HttpRequest("GET", "", data, headers)
-	if err == nil {
-		t.Fatalf("HttpPostRequest without path should fail")
-	}
-}
-
 func getClient() *Client {
 	uri, err := NewURIFromAddress(getPilosaBindAddress())
 	if err != nil {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -36,8 +36,9 @@ package pilosa
 
 import (
 	"bytes"
-		"crypto/tls"
+	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1367,6 +1368,42 @@ func TestStatusToNodeSlicesForIndex(t *testing.T) {
 		}
 	} else {
 		t.Fatalf("slice map should have the correct slice")
+	}
+}
+
+func TestHttpRequest(t *testing.T) {
+	client := getClient()
+	reqData := []byte("")
+	framePath := fmt.Sprintf("/index/%s/frame/%s", index.Name(), "http-test-frame")
+	_, _, err := client.HttpPost(framePath, reqData, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = client.HttpGet("/status", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = client.HttpDelete(framePath, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHttpRequestWithoutPathFails(t *testing.T) {
+	client := getClient()
+	data := []byte("some data")
+	headers := map[string]string{"Foo": "Bar"}
+	_, _, err := client.HttpPost("", data, headers)
+	if err == nil {
+		t.Fatalf("HttpPostRequest without path should fail")
+	}
+	_, _, err = client.HttpGet("", data, headers)
+	if err == nil {
+		t.Fatalf("HttpGetRequest without path should fail")
+	}
+	_, _, err = client.HttpDelete("", data, headers)
+	if err == nil {
+		t.Fatalf("HttpDeleteRequest without path should fail")
 	}
 }
 

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -295,7 +295,7 @@ func TestTopNReturns(t *testing.T) {
 	)
 	client.Query(qry, nil)
 	// XXX: The following is required to make this test pass. See: https://github.com/pilosa/pilosa/issues/625
-	time.Sleep(10 * time.Second)
+	client.HttpPost("/recalculate-caches", nil, nil)
 	response, err := client.Query(frame.TopN(2), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -38,7 +38,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -295,7 +294,7 @@ func TestTopNReturns(t *testing.T) {
 	)
 	client.Query(qry, nil)
 	// XXX: The following is required to make this test pass. See: https://github.com/pilosa/pilosa/issues/625
-	client.HttpPost("/recalculate-caches", nil, nil)
+	client.HttpRequest("POST", "/recalculate-caches", nil, nil)
 	response, err := client.Query(frame.TopN(2), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1373,17 +1372,7 @@ func TestStatusToNodeSlicesForIndex(t *testing.T) {
 
 func TestHttpRequest(t *testing.T) {
 	client := getClient()
-	reqData := []byte("")
-	framePath := fmt.Sprintf("/index/%s/frame/%s", index.Name(), "http-test-frame")
-	_, _, err := client.HttpPost(framePath, reqData, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, _, err = client.HttpGet("/status", nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, _, err = client.HttpDelete(framePath, nil, nil)
+	_, _, err := client.HttpRequest("GET", "/status", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1393,17 +1382,9 @@ func TestHttpRequestWithoutPathFails(t *testing.T) {
 	client := getClient()
 	data := []byte("some data")
 	headers := map[string]string{"Foo": "Bar"}
-	_, _, err := client.HttpPost("", data, headers)
+	_, _, err := client.HttpRequest("GET", "", data, headers)
 	if err == nil {
 		t.Fatalf("HttpPostRequest without path should fail")
-	}
-	_, _, err = client.HttpGet("", data, headers)
-	if err == nil {
-		t.Fatalf("HttpGetRequest without path should fail")
-	}
-	_, _, err = client.HttpDelete("", data, headers)
-	if err == nil {
-		t.Fatalf("HttpDeleteRequest without path should fail")
 	}
 }
 


### PR DESCRIPTION
- Added custom Pilosa server address support for running tests.
- Updated travis config to run tests using https too.
- Added `client.HttpRequest` function which sends an HTTP request to a Pilosa server.
- Using `/recalculate-caches` endpoint to decrease integration test times by 2 * 10 secs.