### PR TITLE
Add QueryOptions.Slices support.

### DIFF
--- a/client.go
+++ b/client.go
@@ -657,6 +657,7 @@ func newHTTPClient(options *ClientOptions) *http.Client {
 func makeRequestData(query string, options *QueryOptions) ([]byte, error) {
 	request := &pbuf.QueryRequest{
 		Query:        query,
+		Slices:       options.Slices,
 		ColumnAttrs:  options.Columns,
 		ExcludeAttrs: options.ExcludeAttrs,
 		ExcludeBits:  options.ExcludeBits,
@@ -748,6 +749,8 @@ func (options *ClientOptions) withDefaults() (updated *ClientOptions) {
 
 // QueryOptions contains options to customize the Query function.
 type QueryOptions struct {
+	// Slices restricts query to a subset of slices. Queries all slices if nil.
+	Slices []uint64
 	// Columns enables returning columns in the query response.
 	Columns bool
 	// ExcludeAttrs inhibits returning attributes

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -151,6 +151,29 @@ func TestResponseDefaults(t *testing.T) {
 
 }
 
+func TestQueryWithSlices(t *testing.T) {
+	Reset()
+	const sliceWidth = 1048576
+	client := getClient()
+	if _, err := client.Query(testFrame.SetBit(1, 100), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Query(testFrame.SetBit(1, sliceWidth), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Query(testFrame.SetBit(1, sliceWidth*3), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := client.Query(testFrame.Bitmap(1), &QueryOptions{Slices: []uint64{0, 3}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bits := response.Result().Bitmap.Bits; !reflect.DeepEqual(bits, []uint64{100, sliceWidth * 3}) {
+		t.Fatalf("Unexpected results: %#v", bits)
+	}
+}
+
 func TestQueryWithColumns(t *testing.T) {
 	Reset()
 	client := getClient()


### PR DESCRIPTION
This commit adds support for specifying individual slices when executing a query:

	client.Query(bitmap, &QueryOptions{Slices: []uint64{0, 3}})

Fixes https://github.com/pilosa/pilosa/issues/641