### PR TITLE
Fixes augmentHeaders function to prevent data races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	go test
 
 test-all:
-	go test -tags=integration
+	go test -race -tags=integration
 
 release:
 	printf "package pilosa\nconst Version = \"$(VERSION)\"" > version.go

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -1499,7 +1499,16 @@ func TestUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
 
+func TestClientRace(t *testing.T) {
+	client := getClient()
+	f := func() {
+		client.Query(testFrame.Bitmap(1))
+	}
+	for i := 0; i < 10; i++ {
+		go f()
+	}
 }
 
 func getClient() *Client {


### PR DESCRIPTION
Adds a data race test. Note that `orm.go` is missing some tests in the master, which will be added in a separate PR.

Fixes #97 