### PR TITLE
remove protobuf master constraint from go-pilosa

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,8 +19,3 @@
 # [[override]]
 #  name = "github.com/x/y"
 #  version = "2.4.0"
-
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/golang/protobuf"


### PR DESCRIPTION
I don't think we need this constraint, and it's causing some incompatibilities.