### PR TITLE
remove repeated call to importNode

### DIFF
--- a/client.go
+++ b/client.go
@@ -457,10 +457,6 @@ func (c *Client) importBits(indexName string, frameName string, slice uint64, bi
 			host:   node.Host,
 			port:   node.Port,
 		}
-		err = c.importNode(uri, bitsToImportRequest(indexName, frameName, slice, bits))
-		if err != nil {
-			return errors.Wrap(err, "setting scheme on uri")
-		}
 		eg.Go(func() error {
 			return c.importNode(uri, bitsToImportRequest(indexName, frameName, slice, bits))
 		})


### PR DESCRIPTION
I think we were actually double importing - this appears to be a bug introduced
by a merge - especially since the error message is wrong.