### PR TITLE
brings back the old ImportValueFrame logic

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -829,7 +829,7 @@ func TestValueCSVImport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = client.ImportValueFrame(frame, "foo", iterator, OptImportBatchSize(10))
+	err = client.ImportValueFrame(frame, "foo", iterator, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1174,7 +1174,7 @@ func TestImportValueIteratorError(t *testing.T) {
 		t.Fatal(err)
 	}
 	iterator := NewCSVValueIterator(&BrokenReader{})
-	err = client.ImportValueFrame(frame, "foo", iterator, OptImportBatchSize(100))
+	err = client.ImportValueFrame(frame, "foo", iterator, 100)
 	if err == nil {
 		t.Fatalf("import value frame should fail with broken reader")
 	}
@@ -1226,7 +1226,7 @@ func TestImportValueFrameFailsIfImportValuesFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = client.ImportValueFrame(frame, "foo", iterator, OptImportBatchSize(10))
+	err = client.ImportValueFrame(frame, "foo", iterator, 10)
 	if err == nil {
 		t.Fatalf("ImportValueFrame should fail if importValues fails")
 	}

--- a/imports.go
+++ b/imports.go
@@ -191,6 +191,19 @@ func NewCSVValueIterator(reader io.Reader) *CSVIterator {
 	return NewCSVIterator(reader, FieldValueCSVUnmarshaller)
 }
 
+func (c *CSVIterator) NextValue() (FieldValue, error) {
+	r, err := c.NextRecord()
+	if err != nil {
+		return FieldValue{}, err
+	}
+	col := r.Uint64Field(0)
+	val := r.Int64Field(1)
+	return FieldValue{
+		ColumnID: col,
+		Value:    val,
+	}, nil
+}
+
 // NextRecord iterates on lines of a Reader.
 // Returns io.EOF on end of iteration.
 func (c *CSVIterator) NextRecord() (Record, error) {


### PR DESCRIPTION
Instead of trying to use the same code for importing bits and values, this
brings back the old value importing code. This fixes a bug where the import
manager logic was using the value instead of the column when trying to calculate
the slice for value imports