### PR TITLE
Added OptFieldSet func

### DIFF
--- a/client.go
+++ b/client.go
@@ -293,7 +293,7 @@ func (c *Client) Schema() (*Schema, error) {
 		for _, fieldInfo := range indexInfo.Fields {
 			fieldOptions := &FieldOptions{
 				fieldType:   fieldInfo.Options.FieldType,
-				cacheSize:   fieldInfo.Options.CacheSize,
+				cacheSize:   int(fieldInfo.Options.CacheSize),
 				cacheType:   CacheType(fieldInfo.Options.CacheType),
 				timeQuantum: TimeQuantum(fieldInfo.Options.TimeQuantum),
 				min:         fieldInfo.Options.Min,

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -466,8 +466,7 @@ func TestSchema(t *testing.T) {
 		t.Fatalf("There should be at least 1 index in the schema")
 	}
 	f, err := index.Field("schema-test-field",
-		CacheTypeLRU,
-		OptFieldCacheSize(9999),
+		OptFieldSet(CacheTypeLRU, 9999),
 	)
 	err = client.EnsureField(f)
 	if err != nil {

--- a/orm.go
+++ b/orm.go
@@ -435,9 +435,9 @@ func (fo *FieldOptions) addOptions(options ...interface{}) error {
 // FieldOption is used to pass an option to index.Field function.
 type FieldOption func(options *FieldOptions) error
 
-// OptFieldInt adds a set field.
+// OptFieldSet adds a set field.
 // Specify CacheTypeDefault for the default cache type.
-// Specify 0 for the default cache size.
+// Specify CacheSizeDefault for the default cache size.
 func OptFieldSet(cacheType CacheType, cacheSize int) FieldOption {
 	return func(options *FieldOptions) error {
 		if cacheSize < 0 {
@@ -689,6 +689,9 @@ const (
 	CacheTypeRanked  CacheType = "ranked"
 	CacheTypeNone    CacheType = "none"
 )
+
+// CacheSizeDefault is the default cache size
+const CacheSizeDefault = 0
 
 // LT creates a less than query.
 func (field *Field) LT(n int) *PQLRowQuery {

--- a/orm.go
+++ b/orm.go
@@ -369,7 +369,7 @@ type FieldOptions struct {
 	fieldType   FieldType
 	timeQuantum TimeQuantum
 	cacheType   CacheType
-	cacheSize   uint
+	cacheSize   int
 	min         int64
 	max         int64
 }
@@ -385,6 +385,13 @@ func (fo FieldOptions) String() string {
 	mopt := map[string]interface{}{}
 
 	switch fo.fieldType {
+	case FieldTypeSet:
+		if fo.cacheType != CacheTypeDefault {
+			mopt["cacheType"] = string(fo.cacheType)
+		}
+		if fo.cacheSize > 0 {
+			mopt["cacheSize"] = fo.cacheSize
+		}
 	case FieldTypeInt:
 		mopt["min"] = fo.min
 		mopt["max"] = fo.max
@@ -394,12 +401,6 @@ func (fo FieldOptions) String() string {
 
 	if fo.fieldType != FieldTypeDefault {
 		mopt["type"] = string(fo.fieldType)
-	}
-	if fo.cacheType != CacheTypeDefault {
-		mopt["cacheType"] = string(fo.cacheType)
-	}
-	if fo.cacheSize != 0 {
-		mopt["cacheSize"] = fo.cacheSize
 	}
 	return fmt.Sprintf(`{"options":%s}`, encodeMap(mopt))
 }
@@ -422,12 +423,8 @@ func (fo *FieldOptions) addOptions(options ...interface{}) error {
 			if err != nil {
 				return err
 			}
-		case FieldType:
-			fo.fieldType = o
 		case TimeQuantum:
 			fo.timeQuantum = o
-		case CacheType:
-			fo.cacheType = o
 		default:
 			return ErrInvalidFieldOption
 		}
@@ -438,10 +435,17 @@ func (fo *FieldOptions) addOptions(options ...interface{}) error {
 // FieldOption is used to pass an option to index.Field function.
 type FieldOption func(options *FieldOptions) error
 
-// OptFieldCacheSize sets the cache size.
-func OptFieldCacheSize(size uint) FieldOption {
+// OptFieldInt adds a set field.
+// Specify CacheTypeDefault for the default cache type.
+// Specify 0 for the default cache size.
+func OptFieldSet(cacheType CacheType, cacheSize int) FieldOption {
 	return func(options *FieldOptions) error {
-		options.cacheSize = size
+		if cacheSize < 0 {
+			return ErrInvalidFieldOption
+		}
+		options.fieldType = FieldTypeSet
+		options.cacheType = cacheType
+		options.cacheSize = cacheSize
 		return nil
 	}
 }
@@ -450,6 +454,9 @@ func OptFieldCacheSize(size uint) FieldOption {
 func OptFieldInt(min int64, max int64) FieldOption {
 	return func(options *FieldOptions) error {
 		options.fieldType = FieldTypeInt
+		if max < min {
+			return ErrInvalidFieldOption
+		}
 		options.min = min
 		options.max = max
 		return nil

--- a/orm_test.go
+++ b/orm_test.go
@@ -222,9 +222,9 @@ func TestFieldToString(t *testing.T) {
 func TestFieldSetType(t *testing.T) {
 	schema1 := NewSchema()
 	index, _ := schema1.Index("test-index")
-	field, _ := index.Field("test-field", FieldTypeSet)
-	target := `{"options":{"type":"set"}}`
-	if target != field.options.String() {
+	field, _ := index.Field("test-field", OptFieldSet(CacheTypeLRU, 1000))
+	target := `{"options":{"type":"set","cacheType":"lru","cacheSize":1000}}`
+	if sortedString(target) != sortedString(field.options.String()) {
 		t.Fatalf("%s != %s", target, field.options.String())
 	}
 }
@@ -626,6 +626,14 @@ func TestInvalidFieldOption(t *testing.T) {
 		t.Fatalf("should have failed")
 	}
 	_, err = sampleIndex.Field("invalid-field-opt", FieldOptionErr(0))
+	if err == nil {
+		t.Fatalf("should have failed")
+	}
+	_, err = sampleIndex.Field("invalid-field-opt", OptFieldInt(10, 9))
+	if err == nil {
+		t.Fatalf("should have failed")
+	}
+	_, err = sampleIndex.Field("invalid-field-opt", OptFieldSet(CacheTypeDefault, -1))
 	if err == nil {
 		t.Fatalf("should have failed")
 	}


### PR DESCRIPTION
Cache type and cache size can only be specified through the OptFieldSet function, since they are only valid for set fields.