### PR TITLE
Removes index/field validation. Updated docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 * **v1.0.0** (2018-06-28)
     * Compatible with Pilosa 1.0.
-    * Removed all deprecated code.
-    * Following terminolgy was changed:
+    * Following terminology was changed:
         * frame to field
         * bitmap to row
         * bit to column
         * slice to shard
-    * Removed `Field` type and renamed `Frame` to `Field`.
     * There are three types of fields:
         * Set fields to store boolean values (default)
         * Integer fields to store an integer in the given range.
         * Time fields which can store timestamps.
+    * Removed all deprecated code.
+    * Removed `Field` type and renamed `Frame` to `Field`.
     * Removed `client.ImportValueField` function. `client.ImportField` function imports both set and integer fields, depending on the type of the field.
     * Removed index and field validation. The validation is done only on the server side. `schema.Index` and `index.Field` functions do not return `error` values.
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         * Integer fields to store an integer in the given range.
         * Time fields which can store timestamps.
     * Removed `client.ImportValueField` function. `client.ImportField` function imports both set and integer fields, depending on the type of the field.
+    * Removed index and field validation. The validation is done only on the server side. `schema.Index` and `index.Field` functions do not return `error` values.
   
 * **v0.9.0** (2018-05-10)
     * Compatible with Pilosa 0.9.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ func main() {
 	schema, err := client.Schema()
 
 	// Create an Index object
-	myindex, err := schema.Index("myindex")
+	myindex := schema.Index("myindex")
 
 	// Create a Field object
-	myfield, err := myindex.Field("myfield")
+	myfield := myindex.Field("myfield")
 
 	// make sure the index and the field exists on the server
 	err = client.SyncSchema(schema)

--- a/client.go
+++ b/client.go
@@ -285,15 +285,9 @@ func (c *Client) Schema() (*Schema, error) {
 	}
 	schema := NewSchema()
 	for _, indexInfo := range indexes {
-		index, err := schema.indexWithOptions(indexInfo.Name, indexInfo.Options.asIndexOptions())
-		if err != nil {
-			return nil, err
-		}
+		index := schema.indexWithOptions(indexInfo.Name, indexInfo.Options.asIndexOptions())
 		for _, fieldInfo := range indexInfo.Fields {
-			_, err := index.fieldWithOptions(fieldInfo.Name, fieldInfo.Options.asFieldOptions())
-			if err != nil {
-				return nil, err
-			}
+			index.fieldWithOptions(fieldInfo.Name, fieldInfo.Options.asFieldOptions())
 		}
 	}
 	return schema, nil

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -57,16 +57,8 @@ var index *Index
 var testField *Field
 
 func TestMain(m *testing.M) {
-	var err error
-	index, err = NewIndex("go-testindex")
-	if err != nil {
-		panic(err)
-	}
-	testField, err = index.Field("test-field")
-	if err != nil {
-		panic(err)
-	}
-
+	index = NewIndex("go-testindex")
+	testField = index.Field("test-field")
 	Setup()
 	r := m.Run()
 	TearDown()
@@ -208,11 +200,8 @@ func TestSetRowAttrs(t *testing.T) {
 
 func TestOrmCount(t *testing.T) {
 	client := getClient()
-	countField, err := index.Field("count-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(countField)
+	countField := index.Field("count-test")
+	err := client.EnsureField(countField)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,11 +222,8 @@ func TestOrmCount(t *testing.T) {
 
 func TestIntersectReturns(t *testing.T) {
 	client := getClient()
-	field, err := index.Field("segments")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("segments")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,11 +249,8 @@ func TestIntersectReturns(t *testing.T) {
 
 func TestTopNReturns(t *testing.T) {
 	client := getClient()
-	field, err := index.Field("topn_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("topn_test")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,12 +283,9 @@ func TestTopNReturns(t *testing.T) {
 
 func TestCreateDeleteIndexField(t *testing.T) {
 	client := getClient()
-	index1, err := NewIndex("to-be-deleted")
-	if err != nil {
-		panic(err)
-	}
-	field1, err := index1.Field("foo")
-	err = client.CreateIndex(index1)
+	index1 := NewIndex("to-be-deleted")
+	field1 := index1.Field("foo")
+	err := client.CreateIndex(index1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,11 +321,8 @@ func TestEnsureFieldExists(t *testing.T) {
 
 func TestCreateFieldWithTimeQuantum(t *testing.T) {
 	client := getClient()
-	field, err := index.Field("field-with-timequantum", OptFieldTime(TimeQuantumYear))
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.CreateField(field)
+	field := index.Field("field-with-timequantum", OptFieldTime(TimeQuantumYear))
+	err := client.CreateField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +442,7 @@ func TestSchema(t *testing.T) {
 	if len(schema.indexes) < 1 {
 		t.Fatalf("There should be at least 1 index in the schema")
 	}
-	f, err := index.Field("schema-test-field",
+	f := index.Field("schema-test-field",
 		OptFieldSet(CacheTypeLRU, 9999),
 	)
 	err = client.EnsureField(f)
@@ -491,21 +468,21 @@ func TestSchema(t *testing.T) {
 
 func TestSync(t *testing.T) {
 	client := getClient()
-	remoteIndex, _ := NewIndex("remote-index-1")
+	remoteIndex := NewIndex("remote-index-1")
 	err := client.EnsureIndex(remoteIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
-	remoteField, _ := remoteIndex.Field("remote-field-1")
+	remoteField := remoteIndex.Field("remote-field-1")
 	err = client.EnsureField(remoteField)
 	if err != nil {
 		t.Fatal(err)
 	}
 	schema1 := NewSchema()
-	index11, _ := schema1.Index("diff-index1")
+	index11 := schema1.Index("diff-index1")
 	index11.Field("field1-1")
 	index11.Field("field1-2")
-	index12, _ := schema1.Index("diff-index2")
+	index12 := schema1.Index("diff-index2")
 	index12.Field("field2-1")
 	schema1.Index(remoteIndex.Name())
 
@@ -546,47 +523,6 @@ func TestErrorRetrievingSchema(t *testing.T) {
 	}
 }
 
-func TestInvalidSchemaInvalidIndex(t *testing.T) {
-	data := []byte(`
-		{
-			"indexes": [{
-				"Name": "**INVALID**"
-			}]
-		}
-	`)
-	server := getMockServer(200, data, len(data))
-	defer server.Close()
-	uri, err := NewURIFromAddress(server.URL)
-	if err != nil {
-		panic(err)
-	}
-	client, _ := NewClient(uri)
-	_, err = client.Schema()
-	if err == nil {
-		t.Fatal("should have failed")
-	}
-}
-
-func TestInvalidSchemaInvalidField(t *testing.T) {
-	data := []byte(`
-		{
-			"indexes": [{
-				"name": "myindex",
-				"fields": [{
-					"name": "**INVALID**"
-				}]
-			}]
-		}
-	`)
-	server := getMockServer(200, data, len(data))
-	defer server.Close()
-	client, _ := NewClient(server.URL)
-	_, err := client.Schema()
-	if err == nil {
-		t.Fatal("should have failed")
-	}
-}
-
 func TestCSVImport(t *testing.T) {
 	client := getClient()
 	text := `10,7
@@ -594,11 +530,8 @@ func TestCSVImport(t *testing.T) {
 		2,3
 		7,1`
 	iterator := NewCSVColumnIterator(strings.NewReader(text))
-	field, err := index.Field("importfield")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("importfield")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -675,11 +608,8 @@ func NewGivenColumnGenerator(recs []Record) *GivenColumnGenerator {
 func TestImportWithTimeout(t *testing.T) {
 	client := getClient()
 	iterator := &ColumnGenerator{numRows: 100, numColumns: 1000}
-	field, err := index.Field("importfield-timeout")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("importfield-timeout")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,11 +623,8 @@ func TestImportWithTimeout(t *testing.T) {
 func TestImportWithBatchSize(t *testing.T) {
 	client := getClient()
 	iterator := &ColumnGenerator{numRows: 10, numColumns: 1000}
-	field, err := index.Field("importfield-batchsize")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("importfield-batchsize")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -735,11 +662,8 @@ func TestImportWithBatchSizeExpectingZero(t *testing.T) {
 		},
 	)
 
-	field, err := index.Field("importfield-batchsize-zero")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("importfield-batchsize-zero")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -760,11 +684,8 @@ func failingImportColumns(indexName string, fieldName string, shard uint64, reco
 func TestImportWithTimeoutFails(t *testing.T) {
 	client := getClient()
 	iterator := &ColumnGenerator{numRows: 10, numColumns: 1000}
-	field, err := index.Field("importfield-timeout")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("importfield-timeout")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -778,11 +699,8 @@ func TestImportWithTimeoutFails(t *testing.T) {
 func TestImportWithBatchSizeFails(t *testing.T) {
 	client := getClient()
 	iterator := &ColumnGenerator{numRows: 10, numColumns: 1000}
-	field, err := index.Field("importfield-batchsize")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.EnsureField(field)
+	field := index.Field("importfield-batchsize")
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -804,13 +722,10 @@ func TestErrorReturningImportOption(t *testing.T) {
 		2,3
 		7,1`
 	iterator := NewCSVColumnIterator(strings.NewReader(text))
-	field, err := index.Field("importfield")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := index.Field("importfield")
 	client := getClient()
 	optionErr := errors.New("ERR")
-	err = client.ImportField(field, iterator, ErrorImportOption(optionErr))
+	err := client.ImportField(field, iterator, ErrorImportOption(optionErr))
 	if err != optionErr {
 		t.Fatal("ImportField should fail if an import option fails")
 	}
@@ -821,18 +736,12 @@ func TestValueCSVImport(t *testing.T) {
 	text := `10,7
 		7,1`
 	iterator := NewCSVValueIterator(strings.NewReader(text))
-	field, err := index.Field("importvaluefield", OptFieldInt(0, 100))
+	field := index.Field("importvaluefield", OptFieldInt(0, 100))
+	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = client.EnsureField(field)
-	if err != nil {
-		t.Fatal(err)
-	}
-	field2, err := index.Field("importvaluefield-set")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field2 := index.Field("importvaluefield-set")
 	err = client.EnsureField(field2)
 	if err != nil {
 		t.Fatal(err)
@@ -872,12 +781,9 @@ func TestValueCSVImportFailure(t *testing.T) {
 
 func TestCSVExport(t *testing.T) {
 	client := getClient()
-	field, err := index.Field("exportfield")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := index.Field("exportfield")
 	client.EnsureField(field)
-	_, err = client.Query(index.BatchQuery(
+	_, err := client.Query(index.BatchQuery(
 		field.Set(1, 1),
 		field.Set(1, 10),
 		field.Set(2, 1048577),
@@ -919,11 +825,8 @@ func TestCSVExportFailure(t *testing.T) {
 	server := getMockServer(404, []byte("sorry, not found"), -1)
 	defer server.Close()
 	client, _ := NewClient(server.URL)
-	field, err := index.Field("exportfield")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = client.ExportField(field)
+	field := index.Field("exportfield")
+	_, err := client.ExportField(field)
 	if err == nil {
 		t.Fatal("should have failed")
 	}
@@ -936,10 +839,7 @@ func TestExportReaderFailure(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	field, err := index.Field("exportfield")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := index.Field("exportfield")
 	shardURIs := map[uint64]*URI{
 		0: uri,
 	}
@@ -959,10 +859,7 @@ func TestExportReaderReadBodyFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	field, err := index.Field("exportfield")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := index.Field("exportfield")
 	shardURIs := map[uint64]*URI{0: uri}
 	client, _ := NewClient(uri)
 	reader := newExportReader(client, shardURIs, field)
@@ -1005,7 +902,7 @@ func TestFetchStatus(t *testing.T) {
 
 func TestRangeQuery(t *testing.T) {
 	client := getClient()
-	field, _ := index.Field("test-rangefield", OptFieldTime(TimeQuantumMonthDayHour))
+	field := index.Field("test-rangefield", OptFieldTime(TimeQuantumMonthDayHour))
 	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -1032,8 +929,8 @@ func TestRangeQuery(t *testing.T) {
 
 func TestRangeField(t *testing.T) {
 	client := getClient()
-	field, _ := index.Field("rangefield", OptFieldInt(10, 20))
-	field2, _ := index.Field("rangefield-set")
+	field := index.Field("rangefield", OptFieldInt(10, 20))
+	field2 := index.Field("rangefield-set")
 	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -1100,7 +997,7 @@ func TestRangeField(t *testing.T) {
 
 func TestExcludeAttrsColumns(t *testing.T) {
 	client := getClient()
-	field, _ := index.Field("excludecolumnsattrsfield")
+	field := index.Field("excludecolumnsattrsfield")
 	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -1143,12 +1040,9 @@ func TestExcludeAttrsColumns(t *testing.T) {
 
 func TestImportColumnIteratorError(t *testing.T) {
 	client := getClient()
-	field, err := index.Field("not-important")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := index.Field("not-important")
 	iterator := NewCSVColumnIterator(&BrokenReader{})
-	err = client.ImportField(field, iterator)
+	err := client.ImportField(field, iterator)
 	if err == nil {
 		t.Fatalf("import field should fail with broken reader")
 	}
@@ -1156,12 +1050,9 @@ func TestImportColumnIteratorError(t *testing.T) {
 
 func TestImportValueIteratorError(t *testing.T) {
 	client := getClient()
-	field, err := index.Field("not-important", OptFieldInt(0, 100))
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := index.Field("not-important", OptFieldInt(0, 100))
 	iterator := NewCSVValueIterator(&BrokenReader{})
-	err = client.ImportField(field, iterator, OptImportBatchSize(100))
+	err := client.ImportField(field, iterator, OptImportBatchSize(100))
 	if err == nil {
 		t.Fatalf("import value field should fail with broken reader")
 	}
@@ -1193,11 +1084,8 @@ func TestImportFieldFailsIfImportColumnsFails(t *testing.T) {
 	defer server.Close()
 	client, _ := NewClient(server.URL)
 	iterator := NewCSVColumnIterator(strings.NewReader("10,7"))
-	field, err := index.Field("importfield1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.ImportField(field, iterator)
+	field := index.Field("importfield1")
+	err := client.ImportField(field, iterator)
 	if err == nil {
 		t.Fatalf("ImportField should fail if importColumns fails")
 	}
@@ -1209,11 +1097,8 @@ func TestImportIntFieldFailsIfImportValuesFails(t *testing.T) {
 	defer server.Close()
 	client, _ := NewClient(server.URL)
 	iterator := NewCSVValueIterator(strings.NewReader("10,7"))
-	field, err := index.Field("import-values-field", OptFieldInt(0, 100))
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.ImportField(field, iterator, OptImportBatchSize(10))
+	field := index.Field("import-values-field", OptFieldInt(0, 100))
+	err := client.ImportField(field, iterator, OptImportBatchSize(10))
 	if err == nil {
 		t.Fatalf("ImportField should fail if importValues fails")
 	}
@@ -1385,7 +1270,7 @@ func TestSyncSchemaCantCreateField(t *testing.T) {
 	defer server.Close()
 	client, _ := NewClient(server.URL)
 	schema = NewSchema()
-	index, _ := schema.Index("foo")
+	index := schema.Index("foo")
 	index.Field("foofield")
 	serverSchema := NewSchema()
 	serverSchema.Index("foo")

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -321,7 +321,7 @@ func TestEnsureFieldExists(t *testing.T) {
 
 func TestCreateFieldWithTimeQuantum(t *testing.T) {
 	client := getClient()
-	field := index.Field("field-with-timequantum", OptFieldTime(TimeQuantumYear))
+	field := index.Field("field-with-timequantum", OptFieldTypeTime(TimeQuantumYear))
 	err := client.CreateField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -443,7 +443,7 @@ func TestSchema(t *testing.T) {
 		t.Fatalf("There should be at least 1 index in the schema")
 	}
 	f := index.Field("schema-test-field",
-		OptFieldSet(CacheTypeLRU, 9999),
+		OptFieldTypeSet(CacheTypeLRU, 9999),
 	)
 	err = client.EnsureField(f)
 	if err != nil {
@@ -736,7 +736,7 @@ func TestValueCSVImport(t *testing.T) {
 	text := `10,7
 		7,1`
 	iterator := NewCSVValueIterator(strings.NewReader(text))
-	field := index.Field("importvaluefield", OptFieldInt(0, 100))
+	field := index.Field("importvaluefield", OptFieldTypeInt(0, 100))
 	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -902,7 +902,7 @@ func TestFetchStatus(t *testing.T) {
 
 func TestRangeQuery(t *testing.T) {
 	client := getClient()
-	field := index.Field("test-rangefield", OptFieldTime(TimeQuantumMonthDayHour))
+	field := index.Field("test-rangefield", OptFieldTypeTime(TimeQuantumMonthDayHour))
 	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -929,7 +929,7 @@ func TestRangeQuery(t *testing.T) {
 
 func TestRangeField(t *testing.T) {
 	client := getClient()
-	field := index.Field("rangefield", OptFieldInt(10, 20))
+	field := index.Field("rangefield", OptFieldTypeInt(10, 20))
 	field2 := index.Field("rangefield-set")
 	err := client.EnsureField(field)
 	if err != nil {
@@ -1050,7 +1050,7 @@ func TestImportColumnIteratorError(t *testing.T) {
 
 func TestImportValueIteratorError(t *testing.T) {
 	client := getClient()
-	field := index.Field("not-important", OptFieldInt(0, 100))
+	field := index.Field("not-important", OptFieldTypeInt(0, 100))
 	iterator := NewCSVValueIterator(&BrokenReader{})
 	err := client.ImportField(field, iterator, OptImportBatchSize(100))
 	if err == nil {
@@ -1097,7 +1097,7 @@ func TestImportIntFieldFailsIfImportValuesFails(t *testing.T) {
 	defer server.Close()
 	client, _ := NewClient(server.URL)
 	iterator := NewCSVValueIterator(strings.NewReader("10,7"))
-	field := index.Field("import-values-field", OptFieldInt(0, 100))
+	field := index.Field("import-values-field", OptFieldTypeInt(0, 100))
 	err := client.ImportField(field, iterator, OptImportBatchSize(10))
 	if err == nil {
 		t.Fatalf("ImportField should fail if importValues fails")

--- a/client_test.go
+++ b/client_test.go
@@ -42,14 +42,8 @@ import (
 func TestQueryWithError(t *testing.T) {
 	var err error
 	client := DefaultClient()
-	index, err := NewIndex("foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	field, err := index.Field("foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := NewIndex("foo")
+	field := index.Field("foo")
 	invalid := field.FilterFieldTopN(12, field.Row(7), "$invalid$", 80, 81)
 	_, err = client.Query(invalid, nil)
 	if err == nil {
@@ -208,7 +202,7 @@ func TestQueryOptionsWithError(t *testing.T) {
 
 func TestQueryOptionsError(t *testing.T) {
 	client := DefaultClient()
-	index, _ := NewIndex("foo")
+	index := NewIndex("foo")
 	_, err := client.Query(index.RawQuery(""), QueryOptionErr(0))
 	if err == nil {
 		t.Fatalf("should have failed")

--- a/docs/data-model-queries.md
+++ b/docs/data-model-queries.md
@@ -8,19 +8,19 @@ The `schema.Index` function is used to create an index object. Note that this do
 
 ```go
 schema := pilosa.NewSchema()
-repository, err := schema.Index("repository")
+repository := schema.Index("repository")
 ```
 
 Field definitions are created with a call to the `Field` function of an index:
 
 ```go
-stargazer, err := repository.Field("stargazer")
+stargazer := repository.Field("stargazer")
 ```
 
 You can pass options to fields:
 
 ```go
-stargazer, err := repository.Field("stargazer", pilosa.OptFieldTime(TimeQuantumYearMonthDay))
+stargazer := repository.Field("stargazer", pilosa.OptFieldTime(TimeQuantumYearMonthDay))
 ```
 
 ## Queries
@@ -57,8 +57,8 @@ This client supports [BSI groups](https://www.pilosa.com/docs/latest/query-langu
 
 In order to use BSI groups, an integer field should be created. The field should have its minimum and maximum set. Here's how you would do that:
 ```go
-index, _ := schema.Index("animals")
-captivity, _ := index.Field("captivity", pilosa.OptFieldInt(0, 956))
+index := schema.Index("animals")
+captivity := index.Field("captivity", pilosa.OptFieldInt(0, 956))
 client.SyncSchema(schema)
 ``` 
 

--- a/docs/data-model-queries.md
+++ b/docs/data-model-queries.md
@@ -20,7 +20,7 @@ stargazer := repository.Field("stargazer")
 You can pass options to fields:
 
 ```go
-stargazer := repository.Field("stargazer", pilosa.OptFieldTime(TimeQuantumYearMonthDay))
+stargazer := repository.Field("stargazer", pilosa.OptFieldTypeTime(TimeQuantumYearMonthDay))
 ```
 
 ## Queries
@@ -58,7 +58,7 @@ This client supports [BSI groups](https://www.pilosa.com/docs/latest/query-langu
 In order to use BSI groups, an integer field should be created. The field should have its minimum and maximum set. Here's how you would do that:
 ```go
 index := schema.Index("animals")
-captivity := index.Field("captivity", pilosa.OptFieldInt(0, 956))
+captivity := index.Field("captivity", pilosa.OptFieldTypeInt(0, 956))
 client.SyncSchema(schema)
 ``` 
 

--- a/docs/server-interaction.md
+++ b/docs/server-interaction.md
@@ -76,10 +76,10 @@ It is possible to customize the behaviour of the underlying HTTP client by passi
 
 ```go
 client, err := pilosa.NewClient(cluster,
-	pilosa.ConnectTimeout(1000),  // if can't connect in  a second, close the connection 
-    pilosa.SocketTimeout(10000),  // if no response received in 10 seconds, close the connection
-    pilosa.PoolSizePerRoute(3),  // number of connections in the pool per host
-    pilosa.TotalPoolSize(10))   // number of total connections in the pool
+	pilosa.OptClientConnectTimeout(1000),  // if can't connect in  a second, close the connection 
+    pilosa.OptClientSocketTimeout(10000),  // if no response received in 10 seconds, close the connection
+    pilosa.OptClientPoolSizePerRoute(3),  // number of connections in the pool per host
+    pilosa.OptClientTotalPoolSize(10))   // number of total connections in the pool
 ```
 
 Once you create a client, you can create indexes, fields or start sending queries.

--- a/orm.go
+++ b/orm.go
@@ -495,10 +495,10 @@ func (fo *FieldOptions) addOptions(options ...FieldOption) {
 // FieldOption is used to pass an option to index.Field function.
 type FieldOption func(options *FieldOptions)
 
-// OptFieldSet adds a set field.
+// OptFieldTypeSet adds a set field.
 // Specify CacheTypeDefault for the default cache type.
 // Specify CacheSizeDefault for the default cache size.
-func OptFieldSet(cacheType CacheType, cacheSize int) FieldOption {
+func OptFieldTypeSet(cacheType CacheType, cacheSize int) FieldOption {
 	return func(options *FieldOptions) {
 		options.fieldType = FieldTypeSet
 		options.cacheType = cacheType
@@ -506,8 +506,8 @@ func OptFieldSet(cacheType CacheType, cacheSize int) FieldOption {
 	}
 }
 
-// OptFieldInt adds an integer field.
-func OptFieldInt(min int64, max int64) FieldOption {
+// OptFieldTypeInt adds an integer field.
+func OptFieldTypeInt(min int64, max int64) FieldOption {
 	return func(options *FieldOptions) {
 		options.fieldType = FieldTypeInt
 		options.min = min
@@ -515,7 +515,7 @@ func OptFieldInt(min int64, max int64) FieldOption {
 	}
 }
 
-func OptFieldTime(quantum TimeQuantum) FieldOption {
+func OptFieldTypeTime(quantum TimeQuantum) FieldOption {
 	return func(options *FieldOptions) {
 		options.fieldType = FieldTypeTime
 		options.timeQuantum = quantum

--- a/orm.go
+++ b/orm.go
@@ -59,25 +59,20 @@ func NewSchema() *Schema {
 }
 
 // Index returns an index with a name.
-func (s *Schema) Index(name string, options ...IndexOption) (*Index, error) {
+func (s *Schema) Index(name string, options ...IndexOption) *Index {
 	if index, ok := s.indexes[name]; ok {
-		return index, nil
+		return index
 	}
 	indexOptions := &IndexOptions{}
-	if err := indexOptions.addOptions(options...); err != nil {
-		return nil, err
-	}
+	indexOptions.addOptions(options...)
 	return s.indexWithOptions(name, indexOptions)
 }
 
-func (s *Schema) indexWithOptions(name string, options *IndexOptions) (*Index, error) {
-	index, err := NewIndex(name)
-	if err != nil {
-		return nil, err
-	}
+func (s *Schema) indexWithOptions(name string, options *IndexOptions) *Index {
+	index := NewIndex(name)
 	index.options = options.withDefaults()
 	s.indexes[name] = index
-	return index, nil
+	return index
 }
 
 // Indexes return a copy of the indexes in this schema
@@ -97,7 +92,7 @@ func (s *Schema) diff(other *Schema) *Schema {
 			result.indexes[indexName] = index.copy()
 		} else {
 			// the index exists in the other schema; check the fields
-			resultIndex, _ := NewIndex(indexName)
+			resultIndex := NewIndex(indexName)
 			for fieldName, field := range index.fields {
 				if _, ok := otherIndex.fields[fieldName]; !ok {
 					// the field doesn't exist in the other schema, copy it
@@ -240,27 +235,22 @@ func (io IndexOptions) String() string {
 	return fmt.Sprintf(`{"options":%s}`, encodeMap(mopt))
 }
 
-func (io *IndexOptions) addOptions(options ...IndexOption) error {
+func (io *IndexOptions) addOptions(options ...IndexOption) {
 	for _, option := range options {
 		if option == nil {
 			continue
 		}
-		err := option(io)
-		if err != nil {
-			return err
-		}
+		option(io)
 	}
-	return nil
 }
 
 // IndexOption is used to pass an option to Index function.
-type IndexOption func(options *IndexOptions) error
+type IndexOption func(options *IndexOptions)
 
 // OptIndexKeys sets whether index uses string keys.
 func OptIndexKeys(keys bool) IndexOption {
-	return func(options *IndexOptions) error {
+	return func(options *IndexOptions) {
 		options.keys = keys
-		return nil
 	}
 }
 
@@ -277,15 +267,12 @@ func (idx *Index) String() string {
 }
 
 // NewIndex creates an index with a name.
-func NewIndex(name string) (*Index, error) {
-	if err := validateIndexName(name); err != nil {
-		return nil, err
-	}
+func NewIndex(name string) *Index {
 	return &Index{
 		name:    name,
 		options: &IndexOptions{},
 		fields:  map[string]*Field{},
-	}, nil
+	}
 }
 
 // Fields return a copy of the fields in this index
@@ -317,28 +304,21 @@ func (idx *Index) Name() string {
 }
 
 // Field creates a Field struct with the specified name and defaults.
-func (idx *Index) Field(name string, options ...FieldOption) (*Field, error) {
+func (idx *Index) Field(name string, options ...FieldOption) *Field {
 	if field, ok := idx.fields[name]; ok {
-		return field, nil
+		return field
 	}
 	fieldOptions := &FieldOptions{}
-	err := fieldOptions.addOptions(options...)
-	if err != nil {
-		return nil, err
-	}
+	fieldOptions.addOptions(options...)
 	return idx.fieldWithOptions(name, fieldOptions)
 }
 
-func (idx *Index) fieldWithOptions(name string, fieldOptions *FieldOptions) (*Field, error) {
-	if err := validateFieldName(name); err != nil {
-		return nil, err
-
-	}
+func (idx *Index) fieldWithOptions(name string, fieldOptions *FieldOptions) *Field {
 	field := newField(name, idx)
 	fieldOptions = fieldOptions.withDefaults()
 	field.options = fieldOptions
 	idx.fields[name] = field
-	return field, nil
+	return field
 }
 
 // BatchQuery creates a batch query with the given queries.
@@ -503,63 +483,49 @@ func (fo FieldOptions) String() string {
 	return fmt.Sprintf(`{"options":%s}`, encodeMap(mopt))
 }
 
-func (fo *FieldOptions) addOptions(options ...FieldOption) error {
+func (fo *FieldOptions) addOptions(options ...FieldOption) {
 	for _, option := range options {
 		if option == nil {
 			continue
 		}
-		err := option(fo)
-		if err != nil {
-			return err
-		}
+		option(fo)
 	}
-	return nil
 }
 
 // FieldOption is used to pass an option to index.Field function.
-type FieldOption func(options *FieldOptions) error
+type FieldOption func(options *FieldOptions)
 
 // OptFieldSet adds a set field.
 // Specify CacheTypeDefault for the default cache type.
 // Specify CacheSizeDefault for the default cache size.
 func OptFieldSet(cacheType CacheType, cacheSize int) FieldOption {
-	return func(options *FieldOptions) error {
-		if cacheSize < 0 {
-			return ErrInvalidFieldOption
-		}
+	return func(options *FieldOptions) {
 		options.fieldType = FieldTypeSet
 		options.cacheType = cacheType
 		options.cacheSize = cacheSize
-		return nil
 	}
 }
 
 // OptFieldInt adds an integer field.
 func OptFieldInt(min int64, max int64) FieldOption {
-	return func(options *FieldOptions) error {
+	return func(options *FieldOptions) {
 		options.fieldType = FieldTypeInt
-		if max < min {
-			return ErrInvalidFieldOption
-		}
 		options.min = min
 		options.max = max
-		return nil
 	}
 }
 
 func OptFieldTime(quantum TimeQuantum) FieldOption {
-	return func(options *FieldOptions) error {
+	return func(options *FieldOptions) {
 		options.fieldType = FieldTypeTime
 		options.timeQuantum = quantum
-		return nil
 	}
 }
 
 // OptFieldKeys sets whether field uses string keys.
 func OptFieldKeys(keys bool) FieldOption {
-	return func(options *FieldOptions) error {
+	return func(options *FieldOptions) {
 		options.keys = keys
-		return nil
 	}
 }
 

--- a/orm_test.go
+++ b/orm_test.go
@@ -33,7 +33,6 @@
 package pilosa
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -43,10 +42,10 @@ import (
 )
 
 var schema = NewSchema()
-var sampleIndex = mustNewIndex(schema, "sample-index")
-var sampleField = mustNewField(sampleIndex, "sample-field")
-var projectIndex = mustNewIndex(schema, "project-index")
-var collabField = mustNewField(projectIndex, "collaboration")
+var sampleIndex = schema.Index("sample-index")
+var sampleField = sampleIndex.Field("sample-field")
+var projectIndex = schema.Index("project-index")
+var collabField = projectIndex.Field("collaboration")
 var b1 = sampleField.Row(10)
 var b2 = sampleField.Row(20)
 var b3 = sampleField.Row(42)
@@ -54,21 +53,21 @@ var b4 = collabField.Row(2)
 
 func TestSchemaDiff(t *testing.T) {
 	schema1 := NewSchema()
-	index11, _ := schema1.Index("diff-index1")
+	index11 := schema1.Index("diff-index1")
 	index11.Field("field1-1")
 	index11.Field("field1-2")
-	index12, _ := schema1.Index("diff-index2")
+	index12 := schema1.Index("diff-index2")
 	index12.Field("field2-1")
 
 	schema2 := NewSchema()
-	index21, _ := schema2.Index("diff-index1")
+	index21 := schema2.Index("diff-index1")
 	index21.Field("another-field")
 
 	targetDiff12 := NewSchema()
-	targetIndex1, _ := targetDiff12.Index("diff-index1")
+	targetIndex1 := targetDiff12.Index("diff-index1")
 	targetIndex1.Field("field1-1")
 	targetIndex1.Field("field1-2")
-	targetIndex2, _ := targetDiff12.Index("diff-index2")
+	targetIndex2 := targetDiff12.Index("diff-index2")
 	targetIndex2.Field("field2-1")
 
 	diff12 := schema1.diff(schema2)
@@ -79,8 +78,8 @@ func TestSchemaDiff(t *testing.T) {
 
 func TestSchemaIndexes(t *testing.T) {
 	schema1 := NewSchema()
-	index11, _ := schema1.Index("diff-index1")
-	index12, _ := schema1.Index("diff-index2")
+	index11 := schema1.Index("diff-index1")
+	index12 := schema1.Index("diff-index2")
 	indexes := schema1.Indexes()
 	target := map[string]*Index{
 		"diff-index1": index11,
@@ -93,7 +92,7 @@ func TestSchemaIndexes(t *testing.T) {
 
 func TestSchemaToString(t *testing.T) {
 	schema1 := NewSchema()
-	index, _ := schema1.Index("test-index")
+	index := schema1.Index("test-index")
 	target := fmt.Sprintf(`map[string]*pilosa.Index{"test-index":(*pilosa.Index)(%p)}`, index)
 	if target != schema1.String() {
 		t.Fatalf("%s != %s", target, schema1.String())
@@ -101,39 +100,20 @@ func TestSchemaToString(t *testing.T) {
 }
 
 func TestNewIndex(t *testing.T) {
-	index1, err := schema.Index("index-name")
-	if err != nil {
-		t.Fatal(err)
-	}
+	index1 := schema.Index("index-name")
 	if index1.Name() != "index-name" {
 		t.Fatalf("index name was not set")
 	}
 	// calling schema.Index again should return the same index
-	index2, err := schema.Index("index-name")
-	if err != nil {
-		t.Fatal(err)
-	}
+	index2 := schema.Index("index-name")
 	if index1 != index2 {
 		t.Fatalf("calling schema.Index again should return the same index")
 	}
 }
 
-func TestNewIndexWithInvalidName(t *testing.T) {
-	_, err := schema.Index("$FOO")
-	if err == nil {
-		t.Fatal(err)
-	}
-}
-
 func TestIndexCopy(t *testing.T) {
-	index, err := schema.Index("my-index-4copy", OptIndexKeys(true))
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = index.Field("my-field-4copy", OptFieldTime(TimeQuantumDayHour))
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := schema.Index("my-index-4copy", OptIndexKeys(true))
+	index.Field("my-field-4copy", OptFieldTime(TimeQuantumDayHour))
 	copiedIndex := index.copy()
 	if !reflect.DeepEqual(index, copiedIndex) {
 		t.Fatalf("copied index should be equivalent")
@@ -141,36 +121,22 @@ func TestIndexCopy(t *testing.T) {
 }
 
 func TestIndexOptions(t *testing.T) {
-	index, err := schema.Index("index-with-options", OptIndexKeys(true))
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := schema.Index("index-with-options", OptIndexKeys(true))
 	target := `{"options":{"keys":true}}`
 	if target != index.options.String() {
 		t.Fatalf("%s != %s", target, index.options.String())
 	}
 }
 
-func TestInvalidIndexOption(t *testing.T) {
-	_, err := schema.Index("index-with-invalid-option", IndexOptionErr(0))
-	if err == nil {
-		t.Fatalf("should have failed")
-	}
-}
-
 func TestNilIndexOption(t *testing.T) {
-	_, err := schema.Index("index-with-nil-option", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	schema.Index("index-with-nil-option", nil)
 }
 
 func TestIndexFields(t *testing.T) {
 	schema1 := NewSchema()
-	index11, _ := schema1.Index("diff-index1")
-	field11, _ := index11.Field("field1-1")
-	field12, _ := index11.Field("field1-2")
+	index11 := schema1.Index("diff-index1")
+	field11 := index11.Field("field1-1")
+	field12 := index11.Field("field1-2")
 	fields := index11.Fields()
 	target := map[string]*Field{
 		"field1-1": field11,
@@ -183,7 +149,7 @@ func TestIndexFields(t *testing.T) {
 
 func TestIndexToString(t *testing.T) {
 	schema1 := NewSchema()
-	index, _ := schema1.Index("test-index")
+	index := schema1.Index("test-index")
 	target := fmt.Sprintf(`&pilosa.Index{name:"test-index", options:(*pilosa.IndexOptions)(%p), fields:map[string]*pilosa.Field{}}`, index.options)
 	if target != index.String() {
 		t.Fatalf("%s != %s", target, index.String())
@@ -191,14 +157,8 @@ func TestIndexToString(t *testing.T) {
 }
 
 func TestField(t *testing.T) {
-	field1, err := sampleIndex.Field("nonexistent-field")
-	if err != nil {
-		t.Fatal(err)
-	}
-	field2, err := sampleIndex.Field("nonexistent-field")
-	if err != nil {
-		t.Fatal(err)
-	}
+	field1 := sampleIndex.Field("nonexistent-field")
+	field2 := sampleIndex.Field("nonexistent-field")
 	if field1 != field2 {
 		t.Fatalf("calling index.Field again should return the same field")
 	}
@@ -208,31 +168,17 @@ func TestField(t *testing.T) {
 }
 
 func TestFieldCopy(t *testing.T) {
-	field, err := sampleIndex.Field("my-field-4copy", OptFieldSet(CacheTypeRanked, 123456))
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := sampleIndex.Field("my-field-4copy", OptFieldSet(CacheTypeRanked, 123456))
 	copiedField := field.copy()
 	if !reflect.DeepEqual(field, copiedField) {
 		t.Fatalf("copied field should be equivalent")
 	}
 }
 
-func TestNewFieldWithInvalidName(t *testing.T) {
-	index, err := NewIndex("foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = index.Field("$$INVALIDFIELD$$")
-	if err == nil {
-		t.Fatal("Creating fields with invalid row labels should fail")
-	}
-}
-
 func TestFieldToString(t *testing.T) {
 	schema1 := NewSchema()
-	index, _ := schema1.Index("test-index")
-	field, _ := index.Field("test-field")
+	index := schema1.Index("test-index")
+	field := index.Field("test-field")
 	target := fmt.Sprintf(`&pilosa.Field{name:"test-field", index:(*pilosa.Index)(%p), options:(*pilosa.FieldOptions)(%p)}`,
 		field.index, field.options)
 	if target != field.String() {
@@ -242,18 +188,21 @@ func TestFieldToString(t *testing.T) {
 
 func TestNilFieldOption(t *testing.T) {
 	schema1 := NewSchema()
-	index, _ := schema1.Index("test-index")
-	_, err := index.Field("test-field-with-nil-option", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := schema1.Index("test-index")
+	index.Field("test-field-with-nil-option", nil)
 }
 
 func TestFieldSetType(t *testing.T) {
 	schema1 := NewSchema()
-	index, _ := schema1.Index("test-index")
-	field, _ := index.Field("test-field", OptFieldSet(CacheTypeLRU, 1000), OptFieldKeys(true))
+	index := schema1.Index("test-index")
+	field := index.Field("test-set-field", OptFieldSet(CacheTypeLRU, 1000), OptFieldKeys(true))
 	target := `{"options":{"type":"set","cacheType":"lru","cacheSize":1000,"keys":true}}`
+	if sortedString(target) != sortedString(field.options.String()) {
+		t.Fatalf("%s != %s", target, field.options.String())
+	}
+
+	field = index.Field("test-set-field2", OptFieldSet(CacheTypeLRU, -10), OptFieldKeys(true))
+	target = `{"options":{"type":"set","cacheType":"lru","keys":true}}`
 	if sortedString(target) != sortedString(field.options.String()) {
 		t.Fatalf("%s != %s", target, field.options.String())
 	}
@@ -612,10 +561,7 @@ func TestRangeK(t *testing.T) {
 }
 
 func TestSetFieldOptions(t *testing.T) {
-	field, err := sampleIndex.Field("set-field", OptFieldSet(CacheTypeRanked, 9999))
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := sampleIndex.Field("set-field", OptFieldSet(CacheTypeRanked, 9999))
 	jsonString := field.options.String()
 	targetString := `{"options":{"type":"set","cacheType":"ranked","cacheSize":9999}}`
 	if sortedString(targetString) != sortedString(jsonString) {
@@ -625,10 +571,7 @@ func TestSetFieldOptions(t *testing.T) {
 }
 
 func TestIntFieldOptions(t *testing.T) {
-	field, err := sampleIndex.Field("int-field", OptFieldInt(-10, 100))
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := sampleIndex.Field("int-field", OptFieldInt(-10, 100))
 	jsonString := field.options.String()
 	targetString := `{"options":{"type":"int","min":-10,"max":100}}`
 	if sortedString(targetString) != sortedString(jsonString) {
@@ -638,31 +581,13 @@ func TestIntFieldOptions(t *testing.T) {
 }
 
 func TestTimeFieldOptions(t *testing.T) {
-	field, err := sampleIndex.Field("time-field", OptFieldTime(TimeQuantumDayHour))
-	if err != nil {
-		t.Fatal(err)
-	}
+	field := sampleIndex.Field("time-field", OptFieldTime(TimeQuantumDayHour))
 	jsonString := field.options.String()
 	targetString := `{"options":{"type":"time","timeQuantum":"DH"}}`
 	if sortedString(targetString) != sortedString(jsonString) {
 		t.Fatalf("`%s` != `%s`", targetString, jsonString)
 	}
 	compareFieldOptions(t, field.Options(), FieldTypeTime, TimeQuantumDayHour, CacheTypeDefault, 0, 0, 0)
-}
-
-func TestInvalidFieldOption(t *testing.T) {
-	_, err := sampleIndex.Field("invalid-field-opt", FieldOptionErr(0))
-	if err == nil {
-		t.Fatalf("should have failed")
-	}
-	_, err = sampleIndex.Field("invalid-field-opt", OptFieldInt(10, 9))
-	if err == nil {
-		t.Fatalf("should have failed")
-	}
-	_, err = sampleIndex.Field("invalid-field-opt", OptFieldSet(CacheTypeDefault, -1))
-	if err == nil {
-		t.Fatalf("should have failed")
-	}
 }
 
 func TestEncodeMapPanicsOnMarshalFailure(t *testing.T) {
@@ -705,37 +630,8 @@ func compareFieldOptions(t *testing.T, opts *FieldOptions, fieldType FieldType, 
 	}
 }
 
-func mustNewIndex(schema *Schema, name string) (index *Index) {
-	index, err := schema.Index(name)
-	if err != nil {
-		panic(err)
-	}
-	return
-}
-
-func mustNewField(index *Index, name string) *Field {
-	var err error
-	field, err := index.Field(name)
-	if err != nil {
-		panic(err)
-	}
-	return field
-}
-
 func sortedString(s string) string {
 	arr := strings.Split(s, "")
 	sort.Strings(arr)
 	return strings.Join(arr, "")
-}
-
-func IndexOptionErr(int) IndexOption {
-	return func(*IndexOptions) error {
-		return errors.New("Some error")
-	}
-}
-
-func FieldOptionErr(int) FieldOption {
-	return func(*FieldOptions) error {
-		return errors.New("Some error")
-	}
 }

--- a/orm_test.go
+++ b/orm_test.go
@@ -113,7 +113,7 @@ func TestNewIndex(t *testing.T) {
 
 func TestIndexCopy(t *testing.T) {
 	index := schema.Index("my-index-4copy", OptIndexKeys(true))
-	index.Field("my-field-4copy", OptFieldTime(TimeQuantumDayHour))
+	index.Field("my-field-4copy", OptFieldTypeTime(TimeQuantumDayHour))
 	copiedIndex := index.copy()
 	if !reflect.DeepEqual(index, copiedIndex) {
 		t.Fatalf("copied index should be equivalent")
@@ -168,7 +168,7 @@ func TestField(t *testing.T) {
 }
 
 func TestFieldCopy(t *testing.T) {
-	field := sampleIndex.Field("my-field-4copy", OptFieldSet(CacheTypeRanked, 123456))
+	field := sampleIndex.Field("my-field-4copy", OptFieldTypeSet(CacheTypeRanked, 123456))
 	copiedField := field.copy()
 	if !reflect.DeepEqual(field, copiedField) {
 		t.Fatalf("copied field should be equivalent")
@@ -195,13 +195,13 @@ func TestNilFieldOption(t *testing.T) {
 func TestFieldSetType(t *testing.T) {
 	schema1 := NewSchema()
 	index := schema1.Index("test-index")
-	field := index.Field("test-set-field", OptFieldSet(CacheTypeLRU, 1000), OptFieldKeys(true))
+	field := index.Field("test-set-field", OptFieldTypeSet(CacheTypeLRU, 1000), OptFieldKeys(true))
 	target := `{"options":{"type":"set","cacheType":"lru","cacheSize":1000,"keys":true}}`
 	if sortedString(target) != sortedString(field.options.String()) {
 		t.Fatalf("%s != %s", target, field.options.String())
 	}
 
-	field = index.Field("test-set-field2", OptFieldSet(CacheTypeLRU, -10), OptFieldKeys(true))
+	field = index.Field("test-set-field2", OptFieldTypeSet(CacheTypeLRU, -10), OptFieldKeys(true))
 	target = `{"options":{"type":"set","cacheType":"lru","keys":true}}`
 	if sortedString(target) != sortedString(field.options.String()) {
 		t.Fatalf("%s != %s", target, field.options.String())
@@ -561,7 +561,7 @@ func TestRangeK(t *testing.T) {
 }
 
 func TestSetFieldOptions(t *testing.T) {
-	field := sampleIndex.Field("set-field", OptFieldSet(CacheTypeRanked, 9999))
+	field := sampleIndex.Field("set-field", OptFieldTypeSet(CacheTypeRanked, 9999))
 	jsonString := field.options.String()
 	targetString := `{"options":{"type":"set","cacheType":"ranked","cacheSize":9999}}`
 	if sortedString(targetString) != sortedString(jsonString) {
@@ -571,7 +571,7 @@ func TestSetFieldOptions(t *testing.T) {
 }
 
 func TestIntFieldOptions(t *testing.T) {
-	field := sampleIndex.Field("int-field", OptFieldInt(-10, 100))
+	field := sampleIndex.Field("int-field", OptFieldTypeInt(-10, 100))
 	jsonString := field.options.String()
 	targetString := `{"options":{"type":"int","min":-10,"max":100}}`
 	if sortedString(targetString) != sortedString(jsonString) {
@@ -581,7 +581,7 @@ func TestIntFieldOptions(t *testing.T) {
 }
 
 func TestTimeFieldOptions(t *testing.T) {
-	field := sampleIndex.Field("time-field", OptFieldTime(TimeQuantumDayHour))
+	field := sampleIndex.Field("time-field", OptFieldTypeTime(TimeQuantumDayHour))
 	jsonString := field.options.String()
 	targetString := `{"options":{"type":"time","timeQuantum":"DH"}}`
 	if sortedString(targetString) != sortedString(jsonString) {

--- a/validate.go
+++ b/validate.go
@@ -37,26 +37,12 @@ import (
 )
 
 const (
-	maxIndexName = 64
-	maxFieldName = 64
-	maxLabel     = 64
-	maxKey       = 64
+	maxLabel = 64
+	maxKey   = 64
 )
 
-var indexNameRegex = regexp.MustCompile("^[a-z][a-z0-9_-]*$")
-var fieldNameRegex = regexp.MustCompile("^[a-z][a-z0-9_-]*$")
 var labelRegex = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
 var keyRegex = regexp.MustCompile("^[A-Za-z0-9_{}+/=.~%:-]*$")
-
-// ValidIndexName returns true if the given index name is valid, otherwise false.
-func ValidIndexName(name string) bool {
-	return len(name) <= maxIndexName && indexNameRegex.Match([]byte(name))
-}
-
-// ValidFieldName returns true if the given field name is valid, otherwise false.
-func ValidFieldName(name string) bool {
-	return len(name) <= maxFieldName && fieldNameRegex.Match([]byte(name))
-}
 
 // ValidLabel returns true if the given label is valid, otherwise false.
 func ValidLabel(label string) bool {
@@ -66,20 +52,6 @@ func ValidLabel(label string) bool {
 // ValidKey returns true if the given key is valid, otherwise false.
 func ValidKey(key string) bool {
 	return len(key) <= maxKey && keyRegex.Match([]byte(key))
-}
-
-func validateIndexName(name string) error {
-	if ValidIndexName(name) {
-		return nil
-	}
-	return ErrInvalidIndexName
-}
-
-func validateFieldName(name string) error {
-	if ValidFieldName(name) {
-		return nil
-	}
-	return ErrInvalidFieldName
 }
 
 func validateLabel(label string) error {

--- a/validate_test.go
+++ b/validate_test.go
@@ -34,55 +34,6 @@ package pilosa
 
 import "testing"
 
-func TestValidateIndexName(t *testing.T) {
-	names := []string{
-		"a", "ab", "ab1", "b-c", "d_e",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}
-	for _, name := range names {
-		if validateIndexName(name) != nil {
-			t.Fatalf("Should be valid index name: %s", name)
-		}
-	}
-}
-
-func TestValidateIndexNameInvalid(t *testing.T) {
-	names := []string{
-		"", "'", "^", "/", "\\", "A", "*", "a:b", "valid?no", "yüce", "1", "_", "-",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-	}
-	for _, name := range names {
-		if validateIndexName(name) == nil {
-			t.Fatalf("Should be invalid index name: %s", name)
-		}
-	}
-}
-
-func TestValidateFieldName(t *testing.T) {
-	names := []string{
-		"a", "ab", "ab1", "b-c", "d_e",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}
-	for _, name := range names {
-		if validateFieldName(name) != nil {
-			t.Fatalf("Should be valid field name: %s", name)
-		}
-	}
-}
-
-func TestValidateFieldNameInvalid(t *testing.T) {
-	names := []string{
-		"", "'", "^", "/", "\\", "A", "*", "a:b", "valid?no", "yüce", "_", "-", ".data", "d.e", "1",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-	}
-	for _, name := range names {
-		if validateFieldName(name) == nil {
-			t.Fatalf("Should be invalid field name: %s", name)
-		}
-	}
-
-}
-
 func TestValidateLabel(t *testing.T) {
 	labels := []string{
 		"a", "ab", "ab1", "d_e", "A", "Bc", "B1", "aB", "b-c",


### PR DESCRIPTION
Removed returning `error` value from `schema.Index` and `index.Field` methods.
```go
index := schema.Index("my-index")
field := index.Field("my-field")
```