### PR TITLE
CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,68 @@
+version: 2
+defaults: &defaults
+  working_directory: /go/src/github.com/pilosa/go-pilosa
+  docker:
+    - image: circleci/golang:1.10
+fast-checkout: &fast-checkout
+  attach_workspace:
+    at: .
+jobs:
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - vendor-cache-{{ checksum "Gopkg.lock" }}
+      - run: "[ -d vendor ] || make vendor"
+      - save_cache:
+          key: vendor-cache-{{ checksum "Gopkg.lock" }}
+          paths:
+            - vendor
+      - persist_to_workspace:
+          root: .
+          paths: "*"
+  linter:
+    <<: *defaults
+    steps:
+      - *fast-checkout
+      - run: go get -u github.com/alecthomas/gometalinter
+      - run: gometalinter --install
+      - run: go get github.com/remyoudompheng/go-misc/deadcode
+      - run: make gometalinter
+  test-golang-1.10: &base-test
+    <<: *defaults
+    steps:
+      - *fast-checkout
+      - run: make test-all
+    docker:
+      - image: circleci/golang:1.10
+      - image: pilosa/pilosa:v1.1.0
+  test-golang-1.9:
+    <<: *base-test
+    docker:
+      - image: circleci/golang:1.9
+      - image: pilosa/pilosa:v1.1.0
+  coverage:
+    <<: *defaults
+    steps:
+      - *fast-checkout
+      - run: make start-pilosa GOOS=linux && sleep 2 && touch vendor && make cover PILOSA_BIND=https://:20101
+      - run: go get github.com/mattn/goveralls && /go/bin/goveralls -service=circle-ci -ignore "gopilosa_pbuf/public.pb.go" -coverprofile=build/coverage.out
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build
+      - linter:
+          requires:
+            - build
+      - test-golang-1.10:
+          requires:
+            - build
+      - test-golang-1.9:
+          requires:
+            - build
+      - coverage:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,12 +43,6 @@ jobs:
     docker:
       - image: circleci/golang:1.9
       - image: pilosa/pilosa:v1.1.0
-  coverage:
-    <<: *defaults
-    steps:
-      - *fast-checkout
-      - run: make start-pilosa GOOS=linux && sleep 2 && touch vendor && make cover PILOSA_BIND=https://:20101
-      - run: go get github.com/mattn/goveralls && /go/bin/goveralls -service=circle-ci -ignore "gopilosa_pbuf/public.pb.go" -coverprofile=build/coverage.out
 workflows:
   version: 2
   test:
@@ -61,8 +55,5 @@ workflows:
           requires:
             - build
       - test-golang-1.9:
-          requires:
-            - build
-      - coverage:
           requires:
             - build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,5 @@ before_install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure
 script:
-  - ./pilosa-master-linux-amd64/pilosa server --metric.diagnostics=false -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key --cluster.disabled static &
-  - PILOSA_BIND="https://:20101" make test-all-race TESTFLAGS=-v
-  - pkill pilosa
   - ./pilosa-master-linux-amd64/pilosa server --metric.diagnostics=false -d http_data &
-  - GOARCH=386 make test-all TESTFLAGS=-v
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore "gopilosa_pbuf/public.pb.go" -flags="-tags=integration fullcoverage"
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore "gopilosa_pbuf/public.pb.go" -flags="-tags=fullcoverage"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
+.PHONY: all cover fast-cover generate-proto test test-all test-all-race gometalinter
 
-.PHONY: all cover fast-cover generate-proto test test-all
-
+PILOSA_VERSION ?= master
+PILOSA_VERSION_ID := pilosa-$(PILOSA_VERSION)-$(GOOS)-amd64
+PILOSA_DOWNLOAD_URL ?= https://s3.amazonaws.com/build.pilosa.com/$(PILOSA_VERSION_ID).tar.gz
 VERSION := $(shell git describe --tags 2> /dev/null || echo unknown)
+GOOS ?= linux
+PILOSA_BIND ?= http://:10101
 
 all: test
 
-cover:
-	go test ./... -cover -tags="integration fullcoverage" $(TESTFLAGS)
+cover: vendor
+	PILOSA_BIND=$(PILOSA_BIND) go test ./... -cover $(TESTFLAGS) -covermode=count -coverprofile=build/coverage.out
 
 fast-cover:
-	go test ./... -cover -tags="integration" $(TESTFLAGS)
+	PILOSA_BIND=$(PILOSA_BIND) go test ./... -cover -tags="nointegration" $(TESTFLAGS)
 
 generate:
 	# This ensures that we don't forget to change the package name if we copy the proto definition from pilosa in order to update it.
@@ -17,14 +21,52 @@ generate:
 	sed -i -e 's/package internal;/package gopilosa_pbuf;/g' gopilosa_pbuf/public.proto
 	protoc --go_out=. gopilosa_pbuf/public.proto
 
-test:
-	go test ./... $(TESTFLAGS)
+test: vendor
+	PILOSA_BIND=$(PILOSA_BIND) go test ./... -tags=nointegration $(TESTFLAGS)
 
-test-all:
-	go test ./... -tags=integration $(TESTFLAGS)
+test-all: vendor
+	PILOSA_BIND=$(PILOSA_BIND) go test ./... $(TESTFLAGS)
 
-test-all-race:
-	go test ./... -race -tags=integration $(TESTFLAGS)
+test-all-race: vendor
+	PILOSA_BIND=$(PILOSA_BIND) $(MAKE) test-all TESTFLAGS=-race
+
+vendor: Gopkg.toml
+	dep ensure -vendor-only
+	touch vendor
 
 release:
 	printf "package pilosa\nconst Version = \"$(VERSION)\"" > version.go
+
+clean:
+	rm -rf build vendor
+
+start-pilosa: build/pilosa.pid
+
+stop-pilosa: build/pilosa.pid
+	kill `cat $<` && rm $< && rm -rf build/https_data
+
+build/pilosa.pid: build/$(PILOSA_VERSION_ID)/pilosa build/test.pilosa.local.key
+	build/$(PILOSA_VERSION_ID)/pilosa server --metric.diagnostics=false -b https://:20101 -d build/https_data --tls.skip-verify --tls.certificate build/test.pilosa.local.crt --tls.key build/test.pilosa.local.key --cluster.disabled static & echo $$! > $@
+
+build/test.pilosa.local.key:
+	openssl req -x509 -newkey rsa:4096 -keyout build/test.pilosa.local.key -out build/test.pilosa.local.crt -days 3650 -nodes -subj "/C=US/ST=Texas/L=Austin/O=Pilosa/OU=Com/CN=test.pilosa.local"
+
+build/$(PILOSA_VERSION_ID)/pilosa: build/$(PILOSA_VERSION_ID).tar.gz
+	cd build && tar xf $(PILOSA_VERSION_ID).tar.gz
+	touch $@
+
+build/$(PILOSA_VERSION_ID).tar.gz:
+	mkdir -p build
+	cd build && wget $(PILOSA_DOWNLOAD_URL)
+
+gometalinter:
+	gometalinter --vendor --disable-all \
+            --deadline=120s \
+            --enable=deadcode \
+            --enable=gochecknoinits \
+            --enable=gofmt \
+            --enable=goimports \
+            --enable=misspell \
+            --enable=vet \
+            --exclude "^gopilosa_pbuf/.*\.go" \
+            ./...

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ PILOSA_BIND ?= http://:10101
 all: test
 
 cover: vendor
-	PILOSA_BIND=$(PILOSA_BIND) go test ./... -cover $(TESTFLAGS) -covermode=count -coverprofile=build/coverage.out
+	PILOSA_BIND=$(PILOSA_BIND) go test ./... -cover $(TESTFLAGS) -tags="fullcoverage" -covermode=count -coverprofile=build/coverage.out
 
 fast-cover:
-	PILOSA_BIND=$(PILOSA_BIND) go test ./... -cover -tags="nointegration" $(TESTFLAGS)
+	PILOSA_BIND=$(PILOSA_BIND) go test ./... -cover $(TESTFLAGS)
 
 generate:
 	# This ensures that we don't forget to change the package name if we copy the proto definition from pilosa in order to update it.

--- a/client_internal_it_test.go
+++ b/client_internal_it_test.go
@@ -1,4 +1,4 @@
-// +build integration
+// +build !nointegration
 
 package pilosa
 

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -1736,7 +1736,7 @@ func getMockServer(statusCode int, response []byte, contentLength int) *httptest
 func fragmentNodesFromURL(url string) []fragmentNode {
 	serverURI := URIFromAddress(url)
 	nodes := []fragmentNode{
-		fragmentNode{
+		{
 			Scheme: serverURI.Scheme(),
 			Host:   serverURI.Host(),
 			Port:   serverURI.Port(),

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 // Copyright 2017 Pilosa Corp.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,6 +29,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
+//
+// +build !nointegration
 
 package pilosa
 


### PR DESCRIPTION
This makes some changes to the Makefile and the CI process. The Makefile now includes integration test orchestration tooling, and multiple Pilosa versions can now be run against the integration tests in CI. This also adds gometalinter. CircleCI improves speed with parallel tests and caching.

This replaces #167 and serves as an alternative to #158.