### PR TITLE
Address minor documentation bitrot.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Please check our [Contributor's Guidelines](https://github.com/pilosa/pilosa/CONTRIBUTING.md).
+Please check our [Contributor's Guidelines](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
 
 1. Fork this repo and add it as upstream: `git remote add upstream git@github.com:pilosa/go-pilosa.git`.
 2. Make sure all tests pass (use `make test-all`) and be sure that the tests cover all statements in your code (we aim for 100% test coverage).

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ func main() {
 	// make sure the index and the field exists on the server
 	err = client.SyncSchema(schema)
 
-	// Send a Set query. PilosaException is thrown if execution of the query fails.
+	// Send a Set query. If err is non-nil, response will be nil.
 	response, err := client.Query(myfield.Set(5, 42))
 
-	// Send a Row query. PilosaException is thrown if execution of the query fails.
+	// Send a Row query. If err is non-nil, response will be nil.
 	response, err = client.Query(myfield.Row(5))
 
 	// Get the result


### PR DESCRIPTION
README.md had references to PilosaException, probably
inherited from the java-pilosa documentation. Also,
CONTRIBUTING.md had the wrong URL for the contribution
guide in the main Pilosa repo (lacking the '/blob/master'
which is needed to look at a specific file).