### PR TITLE
WIP (don't merge) Import experiments

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -138,6 +138,30 @@ func TestQueryWithShards(t *testing.T) {
 	}
 }
 
+func TestExpImport(t *testing.T) {
+	Reset()
+	eclient := NewExpClient(getClient())
+	imp := eclient.NewImporter("go-testindex")
+
+	imp.Add(1, "test-field", 0)
+
+	imp.Flush()
+	err := eclient.Flush()
+	if err != nil {
+		t.Fatalf("flushing importer: %v", err)
+	}
+
+	resp, err := eclient.Query(testField.Row(0))
+	if err != nil {
+		t.Fatalf("querying: %v", err)
+	}
+
+	if resp.Result().Row().Columns[0] != 1 {
+		t.Fatalf("Columns should be [1], but got %v", resp.Result().Row().Columns[0])
+	}
+
+}
+
 func TestQueryWithColumns(t *testing.T) {
 	Reset()
 	client := getClient()

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -789,7 +789,7 @@ func TestImportWithBatchSizeExpectingZero(t *testing.T) {
 	}
 }
 
-func failingImportColumns(field *Field, shard uint64, records []Record, nodes []fragmentNode, options *ImportOptions) error {
+func failingImportColumns(field *Field, shard uint64, records []Record, nodes []FragmentNode, options *ImportOptions) error {
 	if len(records) > 0 {
 		return errors.New("some error")
 	}
@@ -851,7 +851,7 @@ func TestExportReaderReadBodyFailure(t *testing.T) {
 
 func TestFetchFragmentNodes(t *testing.T) {
 	client := getClient()
-	nodes, err := client.fetchFragmentNodes(index.Name(), 0)
+	nodes, err := client.FetchFragmentNodes(index.Name(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -859,7 +859,7 @@ func TestFetchFragmentNodes(t *testing.T) {
 		t.Fatalf("1 node should be returned")
 	}
 	// running the same for coverage
-	nodes, err = client.fetchFragmentNodes(index.Name(), 0)
+	nodes, err = client.FetchFragmentNodes(index.Name(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1152,7 +1152,7 @@ func TestDecodingFragmentNodesFails(t *testing.T) {
 	server := getMockServer(200, []byte("notjson"), 7)
 	defer server.Close()
 	client, _ := NewClient(server.URL)
-	_, err := client.fetchFragmentNodes("foo", 0)
+	_, err := client.FetchFragmentNodes("foo", 0)
 	if err == nil {
 		t.Fatalf("fetchFragmentNodes should fail when response from /fragment/nodes cannot be decoded")
 	}
@@ -2169,9 +2169,9 @@ func getMockServer(statusCode int, response []byte, contentLength int) *httptest
 	return httptest.NewServer(handler)
 }
 
-func fragmentNodesFromURL(url string) []fragmentNode {
+func fragmentNodesFromURL(url string) []FragmentNode {
 	serverURI := URIFromAddress(url)
-	nodes := []fragmentNode{
+	nodes := []FragmentNode{
 		{
 			Scheme: serverURI.Scheme(),
 			Host:   serverURI.Host(),

--- a/experiment.go
+++ b/experiment.go
@@ -1,0 +1,153 @@
+package pilosa
+
+import (
+	"sync"
+
+	"github.com/pilosa/pilosa/roaring"
+	"github.com/pkg/errors"
+)
+
+type ExpClient struct {
+	*Client
+	importers map[string]*threadsafeImporter
+	mu        sync.RWMutex
+}
+
+func NewExpClient(c *Client) *ExpClient {
+	return &ExpClient{
+		Client:    c,
+		importers: make(map[string]*threadsafeImporter),
+	}
+}
+
+func (e *ExpClient) Flush() error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for index, tsi := range e.importers {
+		err := e.importIndex(index, tsi)
+		if err != nil {
+			return errors.Wrapf(err, "import index '%s'", index)
+		}
+	}
+	return nil
+}
+
+func (e *ExpClient) importIndex(index string, tsi *threadsafeImporter) error {
+	tsi.mu.RLock()
+	defer tsi.mu.RUnlock()
+	for fs, safeBM := range tsi.fragments {
+		err := e.importFragment(index, fs, safeBM)
+		if err != nil {
+			return errors.Wrapf(err, "importing fragment %v", fs)
+		}
+	}
+	return nil
+}
+
+func (e *ExpClient) importFragment(index string, fs fieldShard, safeBM *safeBitmap) error {
+	nodes, err := e.Client.FetchFragmentNodes(index, fs.shard)
+	if err != nil {
+		return errors.Wrap(err, "fetching frag nodes")
+	}
+	safeBM.mu.Lock()
+	defer safeBM.mu.Unlock()
+	err = e.Client.ImportRoaringBitmap(nodes[0].URI(),
+		&Field{name: fs.field, index: &Index{name: index}},
+		fs.shard, ViewImports{"": safeBM.Bitmap}, &ImportOptions{},
+	)
+	if err != nil {
+		return errors.Wrap(err, "importing")
+	}
+	safeBM.Bitmap = roaring.NewBitmap() // TODO somehow reset to avoid allocating
+	return nil
+}
+
+// ExpImporter is a thread-unsafe importer.
+type ExpImporter struct {
+	index      string
+	fragments  map[fieldShard]*roaring.Bitmap
+	ShardWidth uint64
+	tsImporter *threadsafeImporter
+}
+
+type fieldShard struct {
+	field string
+	shard uint64
+}
+
+func (c *ExpClient) NewImporter(index string) *ExpImporter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.importers[index]; !ok {
+		c.importers[index] = newThreadsafeImporter(index)
+	}
+	return &ExpImporter{
+		index:      index,
+		fragments:  make(map[fieldShard]*roaring.Bitmap),
+		ShardWidth: 1048576,
+		tsImporter: c.importers[index],
+	}
+}
+
+func (i *ExpImporter) Add(col uint64, field string, row uint64) {
+	fs := fieldShard{field: field, shard: col / i.ShardWidth}
+	bm, ok := i.fragments[fs]
+	if !ok {
+		bm = roaring.NewBitmap()
+		i.fragments[fs] = bm
+	}
+	bm.DirectAdd(row*i.ShardWidth + col%i.ShardWidth)
+}
+
+func (i *ExpImporter) Flush() {
+	i.tsImporter.mu.RLock() // TODO consider moving this into the loop
+	for fs, bm := range i.fragments {
+		safeBM, ok := i.tsImporter.fragments[fs]
+		if !ok {
+			i.tsImporter.mu.RUnlock()
+			i.tsImporter.mu.Lock()
+			safeBM, ok = i.tsImporter.fragments[fs]
+			if !ok {
+				safeBM = newSafeBitmap()
+				i.tsImporter.fragments[fs] = safeBM
+			}
+			i.tsImporter.mu.Unlock()
+			i.tsImporter.mu.RLock()
+		}
+		safeBM.UnionInPlace(bm)
+	}
+	i.tsImporter.mu.RUnlock()
+	for fs := range i.fragments {
+		delete(i.fragments, fs)
+	}
+}
+
+type threadsafeImporter struct {
+	index     string
+	fragments map[fieldShard]*safeBitmap
+	mu        sync.RWMutex
+}
+
+func newThreadsafeImporter(index string) *threadsafeImporter {
+	return &threadsafeImporter{
+		index:     index,
+		fragments: make(map[fieldShard]*safeBitmap),
+	}
+}
+
+type safeBitmap struct {
+	*roaring.Bitmap
+	mu sync.Mutex
+}
+
+func newSafeBitmap() *safeBitmap {
+	return &safeBitmap{
+		Bitmap: roaring.NewBitmap(),
+	}
+}
+
+func (b *safeBitmap) UnionInPlace(others ...*roaring.Bitmap) {
+	b.mu.Lock()
+	b.Bitmap.UnionInPlace(others...)
+	b.mu.Unlock()
+}

--- a/import_manager.go
+++ b/import_manager.go
@@ -97,7 +97,7 @@ func recordImportWorker(id int, client *Client, field *Field, chans importWorker
 	statusChan := chans.status
 	recordChan := chans.records
 	errChan := chans.errs
-	shardNodes := map[uint64][]fragmentNode{}
+	shardNodes := map[uint64][]FragmentNode{}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -109,7 +109,7 @@ func recordImportWorker(id int, client *Client, field *Field, chans importWorker
 	}()
 
 	importRecords := func(shard uint64, records []Record) error {
-		var nodes []fragmentNode
+		var nodes []FragmentNode
 		var ok bool
 		var err error
 		if nodes, ok = shardNodes[shard]; !ok {
@@ -119,9 +119,9 @@ func recordImportWorker(id int, client *Client, field *Field, chans importWorker
 				if err != nil {
 					return err
 				}
-				nodes = []fragmentNode{node}
+				nodes = []FragmentNode{node}
 			} else {
-				nodes, err = client.fetchFragmentNodes(field.index.name, shard)
+				nodes, err = client.FetchFragmentNodes(field.index.name, shard)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
playing around with possible performance improvements of a different import architecture.

The basic idea is to use roaring as early as possible and avoid any per-record locking. To do this, we expose a NON-threadsafe importer which immediately builds roaring bitmap fragment files from the bits added to it. The user would get one of these importers for each of their import threads, and then go-pilosa will (via some strategy) periodically merge them together client side and actually import them to Pilosa.