### PR TITLE
performance tweaks

### DIFF
--- a/client.go
+++ b/client.go
@@ -405,7 +405,9 @@ func (c *Client) importColumns(field *Field,
 		return c.importColumnsRoaring(field, shard, records, nodes, options, state)
 	}
 
-	sort.Sort(recordSort(records))
+	if !options.skipSort {
+		sort.Sort(recordSort(records))
+	}
 
 	for _, node := range nodes {
 		uri := node.URI()
@@ -1317,6 +1319,7 @@ type ImportOptions struct {
 	clear              bool
 	rowKeyCacheSize    int
 	columnKeyCacheSize int
+	skipSort           bool
 }
 
 func (opt *ImportOptions) withDefaults() (updated ImportOptions) {
@@ -1380,6 +1383,23 @@ func OptImportClear(clear bool) ImportOption {
 func OptImportRoaring(enable bool) ImportOption {
 	return func(options *ImportOptions) error {
 		options.wantRoaring = enable
+		return nil
+	}
+}
+
+// OptImportSort tells the importer whether or not to sort batches of records, on
+// by default. Sorting imposes some performance cost, especially on data that's
+// already sorted, but dramatically improves performance in pathological
+// cases. It is enabled by default because the pathological cases are awful,
+// and the performance hit is comparatively small, but the performance cost can
+// be significant if you know your data is sorted.
+func OptImportSort(sorting bool) ImportOption {
+	return func(options *ImportOptions) error {
+		// skipSort is expressed negatively because we want to
+		// keep sorting enabled by default, so the zero value should
+		// be that default behavior. The client option expresses it
+		// positively because that's easier for API users.
+		options.skipSort = !sorting
 		return nil
 	}
 }

--- a/import_manager.go
+++ b/import_manager.go
@@ -128,6 +128,9 @@ readRecords:
 	for record := range recordChan {
 		recordCount++
 		shard := record.Shard(shardWidth)
+		if batchForShard[shard] == nil {
+			batchForShard[shard] = make([]Record, 0, batchSize)
+		}
 		batchForShard[shard] = append(batchForShard[shard], record)
 
 		if recordCount >= batchSize {
@@ -139,7 +142,7 @@ readRecords:
 				if err != nil {
 					break readRecords
 				}
-				batchForShard[shard] = nil
+				batchForShard[shard] = batchForShard[shard][:0]
 			}
 			recordCount = 0
 		}

--- a/import_manager.go
+++ b/import_manager.go
@@ -3,6 +3,7 @@ package pilosa
 import (
 	"fmt"
 	"io"
+	"sort"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/simplelru"
@@ -192,6 +193,9 @@ func importRecords(id int, client *Client, field *Field,
 		}
 	}
 	tic := time.Now()
+	if !options.skipSort {
+		sort.Sort(recordSort(records))
+	}
 	err = importFun(field, shard, records, nodes, options, state)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is some low-hanging fruit for improving client runtime. Actual wall-clock time is barely affected by this, which makes me suspect that some of that is server-side, but I haven't diagnosed it more clearly, I just wanted to get a bunch of the easy things out there for review.

Before:
```
    real    0m43.058s
    user    1m12.904s
    sys     0m1.072s
```

After:
```
    real    0m40.063s
    user    0m29.443s
    sys     0m0.888s
```

This certainly frees up a lot of CPU time, but the impact on wall-clock time is trivial thus far.