### PR TITLE
[Urgent] Added RowRange call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * Removed support for Go 1.9.
     * Added `Rows` and `GroupBy` calls.
     * Added roaring import support for `RowKeyColumnID`, `RowIDColumnKey` and `RowKeyColumnKey` type data. Pass `OptImportRoaring(true)` to `client.ImportField` to activate that.
+    * Deprecated `Range` call. Use `RowRange` instead.
 
 * **v1.2.0** (2018-12-21)
     * **Compatible with Pilosa 1.2**

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -939,9 +939,9 @@ func TestFetchStatus(t *testing.T) {
 	}
 }
 
-func TestRangeQuery(t *testing.T) {
+func TestRowRangeQuery(t *testing.T) {
 	client := getClient()
-	field := index.Field("test-rangefield", OptFieldTypeTime(TimeQuantumMonthDayHour))
+	field := index.Field("test-rowrangefield", OptFieldTypeTime(TimeQuantumMonthDayHour))
 	err := client.EnsureField(field)
 	if err != nil {
 		t.Fatal(err)
@@ -956,7 +956,7 @@ func TestRangeQuery(t *testing.T) {
 	}
 	start := time.Date(2017, time.January, 5, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2018, time.January, 5, 0, 0, 0, 0, time.UTC)
-	resp, err := client.Query(field.Range(10, start, end))
+	resp, err := client.Query(field.RowRange(10, start, end))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1707,7 +1707,7 @@ func TestRowIDColumnIDTimestampImportRoaring(t *testing.T) {
 	target = []uint64{5, 7}
 	start := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-	response, err = client.Query(field.Range(10, start, end))
+	response, err = client.Query(field.RowRange(10, start, end))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1779,7 +1779,10 @@ func TestRowIDColumnIDTimestampImportRoaringNoStandardView(t *testing.T) {
 	target = []uint64{5, 7}
 	start := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-	response, err = client.Query(field.Range(10, start, end))
+	response, err = client.Query(field.RowRange(10, start, end))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(target, response.Result().Row().Columns) {
 		t.Fatalf("%v != %v", target, response.Result().Row().Columns)
 	}

--- a/docs/data-model-queries.md
+++ b/docs/data-model-queries.md
@@ -137,6 +137,7 @@ Field:
 * `RowTopN(n uint64, row *PQLRowQuery) *PQLRowQuery`
 * `FilterFieldTopN(n uint64, row *PQLRowQuery, field string, values ...interface{}) *PQLRowQuery`
 * `Range(rowID uint64, start time.Time, end time.Time) *PQLRowQuery`
+* `RowRange(rowID uint64, start time.Time, end time.Time) *PQLRowQuery`
 * `SetRowAttrs(rowID uint64, attrs map[string]interface{}) *PQLBaseQuery`
 * `ClearRow(rowIDOrKey interface{}) *PQLBaseQuery`
 * `Store(row *PQLRowQuery, rowIDOrKey interface{}) *PQLBaseQuery`

--- a/orm.go
+++ b/orm.go
@@ -893,7 +893,21 @@ func (f *Field) filterAttrTopN(n uint64, row *PQLRowQuery, field string, values 
 
 // Range creates a Range query.
 // Similar to Row, but only returns columns which were set with timestamps between the given start and end timestamps.
+// *Deprecated at Pilosa 1.3*
 func (f *Field) Range(rowIDOrKey interface{}, start time.Time, end time.Time) *PQLRowQuery {
+	rowStr, err := formatIDKeyBool(rowIDOrKey)
+	if err != nil {
+		return NewPQLRowQuery("", f.index, err)
+	}
+	text := fmt.Sprintf("Range(%s=%s,%s,%s)", f.name, rowStr, start.Format(timeFormat), end.Format(timeFormat))
+	q := NewPQLRowQuery(text, f.index, nil)
+	return q
+}
+
+// RowRange creates a Row query with timestamps.
+// Similar to Row, but only returns columns which were set with timestamps between the given start and end timestamps.
+// *Introduced at Pilosa 1.3*
+func (f *Field) RowRange(rowIDOrKey interface{}, start time.Time, end time.Time) *PQLRowQuery {
 	rowStr, err := formatIDKeyBool(rowIDOrKey)
 	if err != nil {
 		return NewPQLRowQuery("", f.index, err)

--- a/orm_test.go
+++ b/orm_test.go
@@ -624,14 +624,31 @@ func TestRange(t *testing.T) {
 	start := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2000, time.February, 2, 3, 4, 0, 0, time.UTC)
 	comparePQL(t,
-		"Row(collaboration=10,from='1970-01-01T00:00',to='2000-02-02T03:04')",
+		"Range(collaboration=10,1970-01-01T00:00,2000-02-02T03:04)",
 		collabField.Range(10, start, end))
 
 	comparePQL(t,
-		"Row(collaboration='foo',from='1970-01-01T00:00',to='2000-02-02T03:04')",
+		"Range(collaboration='foo',1970-01-01T00:00,2000-02-02T03:04)",
 		collabField.Range("foo", start, end))
 
 	q := collabField.Range(nil, start, end)
+	if q.err == nil {
+		t.Fatalf("should have failed")
+	}
+}
+
+func TestRowRange(t *testing.T) {
+	start := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2000, time.February, 2, 3, 4, 0, 0, time.UTC)
+	comparePQL(t,
+		"Row(collaboration=10,from='1970-01-01T00:00',to='2000-02-02T03:04')",
+		collabField.RowRange(10, start, end))
+
+	comparePQL(t,
+		"Row(collaboration='foo',from='1970-01-01T00:00',to='2000-02-02T03:04')",
+		collabField.RowRange("foo", start, end))
+
+	q := collabField.RowRange(nil, start, end)
 	if q.err == nil {
 		t.Fatalf("should have failed")
 	}


### PR DESCRIPTION
This PR restores `Range` function to use `Range` call (it was changed to use `Row`) since otherwise the client becomes incompatible with Pilosa < master. Added `RowRange` query for Pilosa >= master.