### PR TITLE
add client method for /info endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -685,7 +685,21 @@ func (c *Client) ExportField(field *Field) (io.Reader, error) {
 	return newExportReader(c, shardURIs, field), nil
 }
 
-// Status returns the serves status.
+// Info returns the server's configuration/host information.
+func (c *Client) Info() (Info, error) {
+	_, data, err := c.httpRequest("GET", "/info", nil, nil, false)
+	if err != nil {
+		return Info{}, errors.Wrap(err, "requesting /info")
+	}
+	info := Info{}
+	err = json.Unmarshal(data, &info)
+	if err != nil {
+		return Info{}, errors.Wrap(err, "unmarshaling /info data")
+	}
+	return info, nil
+}
+
+// Status returns the server's status.
 func (c *Client) Status() (Status, error) {
 	_, data, err := c.httpRequest("GET", "/status", nil, nil, false)
 	if err != nil {
@@ -1420,6 +1434,16 @@ func (node fragmentNode) URI() *URI {
 		host:   node.Host,
 		port:   node.Port,
 	}
+}
+
+// Info contains the configuration/host information from a Pilosa server.
+type Info struct {
+	ShardWidth       uint64 `json:"shardWidth"`       // width of each shard
+	Memory           uint64 `json:"memory"`           // approximate host physical memory
+	CPUType          string `json:"cpuType"`          // "brand name string" from cpuid
+	CPUPhysicalCores int    `json:"CPUPhysicalCores"` // physical cores (cpuid)
+	CPULogicalCores  int    `json:"CPULogicalCores"`  // logical cores cpuid
+	CPUMHz           uint64 `json:"CPUMHz"`           // estimated clock speed
 }
 
 // Status contains the status information from a Pilosa server.

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -942,6 +942,29 @@ func TestFetchStatus(t *testing.T) {
 	}
 }
 
+func TestFetchInfo(t *testing.T) {
+	client := getClient()
+	info, err := client.Info()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.ShardWidth == 0 {
+		t.Fatalf("shard width should not be zero")
+	}
+	if info.Memory < (512 * 1024 * 1024) {
+		t.Fatalf("server memory [%d bytes] under 512MB seems highly improbable", info.Memory)
+	}
+	if info.CPUPhysicalCores < 1 || info.CPULogicalCores < 1 {
+		t.Fatalf("server did not detect any CPU cores")
+	}
+	if info.CPUType == "" {
+		t.Fatalf("server reported empty string for CPU type")
+	}
+	if info.CPUMHz == 0 {
+		t.Fatalf("server reported 0MHz processor")
+	}
+}
+
 func TestRowRangeQuery(t *testing.T) {
 	client := getClient()
 	field := index.Field("test-rowrangefield", OptFieldTypeTime(TimeQuantumMonthDayHour))


### PR DESCRIPTION
This unpacks additional server data which is added to the
server by a corresponding PR, and adds a direct call for
the /info endpoint as a convenience feature. This is intended
to be helpful for benchmarking-type functionality.