### PR TITLE
Exported query serialization

### DIFF
--- a/client.go
+++ b/client.go
@@ -194,12 +194,12 @@ func (c *Client) Query(query PQLQuery, options ...interface{}) (*QueryResponse, 
 	if err != nil {
 		return nil, err
 	}
-	serializedQuery := query.serialize()
+	serializedQuery := query.Serialize()
 	data, err := makeRequestData(serializedQuery.String(), queryOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "making request data")
 	}
-	useCoordinator := serializedQuery.HasKeys
+	useCoordinator := serializedQuery.HasWriteKeys()
 	path := fmt.Sprintf("/index/%s/query", query.Index().name)
 	_, buf, err := c.httpRequest("POST", path, data, defaultProtobufHeaders(), useCoordinator)
 	if err != nil {

--- a/orm_test.go
+++ b/orm_test.go
@@ -957,7 +957,7 @@ func TestFormatIDKey(t *testing.T) {
 
 func comparePQL(t *testing.T, target string, q PQLQuery) {
 	t.Helper()
-	pql := q.serialize().String()
+	pql := q.Serialize().String()
 	if target != pql {
 		t.Fatalf("%s != %s", target, pql)
 	}


### PR DESCRIPTION
It is useful to peek at what a query is for debugging, etc. This PR exports the query serialization interface.