### PR TITLE
add import logging functionality

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,6 +80,10 @@ type Client struct {
 	coordinatorLock    *sync.RWMutex
 	manualFragmentNode *fragmentNode
 	manualServerURI    *URI
+
+	importLogFile    *os.File
+	importLogEncoder Encoder
+	logLock          sync.Mutex
 }
 
 // DefaultClient creates a client with the default address and options.
@@ -124,10 +128,21 @@ func newClientWithOptions(options *ClientOptions) *Client {
 		options = &ClientOptions{}
 	}
 	options = options.withDefaults()
+
 	c := &Client{
 		client:          newHTTPClient(options.withDefaults()),
 		logger:          log.New(os.Stderr, "go-pilosa ", log.Flags()),
 		coordinatorLock: &sync.RWMutex{},
+	}
+	if options.logLoc != nil {
+		var err error
+		c.importLogFile, err = ioutil.TempFile(*options.logLoc, "go-pilosaImport")
+		if err != nil {
+			c.logger.Printf("ERROR: couldn't create temp file for logging imports: %v", err)
+		} else {
+			c.logger.Printf("Logging imports to %v", c.importLogFile.Name())
+		}
+		c.importLogEncoder = NewImportLogEncoder(c.importLogFile)
 	}
 	c.importManager = newRecordImportManager(c)
 	return c
@@ -606,7 +621,7 @@ func (c *Client) importNode(uri *URI, request *pbuf.ImportRequest, options *Impo
 	if err != nil {
 		return errors.Wrap(err, "marshaling to protobuf")
 	}
-	return c.importData(uri, request.GetIndex(), request.GetField(), data, options)
+	return c.importData(uri, request.GetIndex(), request.GetField(), data, options, request.Shard)
 }
 
 func (c *Client) importValueNode(uri *URI, request *pbuf.ImportValueRequest, options *ImportOptions) error {
@@ -614,13 +629,14 @@ func (c *Client) importValueNode(uri *URI, request *pbuf.ImportValueRequest, opt
 	if err != nil {
 		return errors.Wrap(err, "marshaling to protobuf")
 	}
-	return c.importData(uri, request.GetIndex(), request.GetField(), data, options)
+	return c.importData(uri, request.GetIndex(), request.GetField(), data, options, request.Shard)
 }
 
-func (c *Client) importData(uri *URI, indexName string, fieldName string, data []byte, options *ImportOptions) error {
+func (c *Client) importData(uri *URI, indexName string, fieldName string, data []byte, options *ImportOptions, shard uint64) error {
 	params := url.Values{}
 	params.Add("clear", strconv.FormatBool(options.clear))
 	path := fmt.Sprintf("/index/%s/field/%s/import?%s", indexName, fieldName, params.Encode())
+	c.logImport(indexName, path, shard, data)
 	resp, err := c.doRequest(uri, "POST", path, defaultProtobufHeaders(), bytes.NewReader(data))
 	if err = anyError(resp, err); err != nil {
 		return errors.Wrap(err, "doing import")
@@ -654,6 +670,9 @@ func (c *Client) importRoaringBitmap(uri *URI, field *Field, shard uint64, views
 	if err != nil {
 		return err
 	}
+
+	c.logImport(field.index.Name(), path, shard, data)
+
 	resp, err := c.doRequest(uri, "POST", path, defaultProtobufHeaders(), bytes.NewReader(data))
 	if err = anyError(resp, err); err != nil {
 		return errors.Wrap(err, "doing import")
@@ -921,6 +940,54 @@ func (c *Client) translateKeys(req *pbuf.TranslateKeysRequest, keys []string) ([
 	return idsResp.IDs, nil
 }
 
+func (c *Client) logImport(index, path string, shard uint64, data []byte) {
+	if c.importLogFile == nil {
+		return
+	}
+	c.logLock.Lock()
+	go func() {
+		defer c.logLock.Unlock()
+		l := &importLog{
+			Index: index,
+			Path:  path,
+			Shard: shard,
+			Data:  data,
+		}
+		// Encode is actually threadsafe (with gob), but the lock above is
+		// helpful for knowing when we've finished all these goroutines.
+		err := c.importLogEncoder.Encode(l)
+		if err != nil {
+			c.logger.Printf("writing to import log: %v", err)
+		}
+	}()
+}
+
+func (c *Client) replayImport(r io.Reader) error {
+	dec := NewImportLogDecoder(r)
+	for {
+		l := &importLog{}
+		err := dec.Decode(l)
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return errors.Wrap(err, "decoding")
+		}
+
+		nodes, err := c.fetchFragmentNodes(l.Index, l.Shard)
+		if err != nil {
+			return errors.Wrap(err, "fetching fragment nodes")
+		}
+
+		for _, node := range nodes {
+			resp, err := c.doRequest(node.URI(), "POST", l.Path, defaultProtobufHeaders(), bytes.NewReader(l.Data))
+			if err = anyError(resp, err); err != nil {
+				return errors.Wrap(err, "doing import")
+			}
+			resp.Body.Close()
+		}
+	}
+}
+
 func defaultProtobufHeaders() map[string]string {
 	return map[string]string{
 		"Content-Type": "application/x-protobuf",
@@ -1133,6 +1200,8 @@ type ClientOptions struct {
 	TotalPoolSize       int
 	TLSConfig           *tls.Config
 	manualServerAddress bool
+
+	logLoc *string
 }
 
 func (co *ClientOptions) addOptions(options ...ClientOption) error {
@@ -1192,6 +1261,13 @@ func OptClientTLSConfig(config *tls.Config) ClientOption {
 func OptClientManualServerAddress(enabled bool) ClientOption {
 	return func(options *ClientOptions) error {
 		options.manualServerAddress = enabled
+		return nil
+	}
+}
+
+func OptClientLogImports(loc string) ClientOption {
+	return func(options *ClientOptions) error {
+		options.logLoc = &loc
 		return nil
 	}
 }

--- a/client_internal_it_test.go
+++ b/client_internal_it_test.go
@@ -56,7 +56,7 @@ func TestAnyError(t *testing.T) {
 
 func TestImportWithReplay(t *testing.T) {
 	buf := &bytes.Buffer{}
-	client := getClient(OptClientLogImports(buf))
+	client := getClient(ExperimentalOptClientLogImports(buf))
 
 	// the first iterator for creating the target
 	iterator := &ColumnGenerator{numRows: 10, numColumns: 1000}
@@ -100,7 +100,7 @@ func TestImportWithReplay(t *testing.T) {
 		t.Fatalf("should have a log encoder")
 	}
 
-	err = client.ReplayImport(buf)
+	err = client.ExperimentalReplayImport(buf)
 	if err != nil {
 		t.Fatalf("replaying import: %v", err)
 	}

--- a/client_internal_it_test.go
+++ b/client_internal_it_test.go
@@ -113,7 +113,7 @@ func TestImportWithReplay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening import log file: %v", err)
 	}
-	err = client.replayImport(f)
+	err = client.ReplayImport(f)
 	if err != nil {
 		t.Fatalf("replaying import: %v", err)
 	}

--- a/client_internal_it_test.go
+++ b/client_internal_it_test.go
@@ -4,8 +4,10 @@ package pilosa
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 	"testing/iotest"
@@ -50,5 +52,79 @@ func TestAnyError(t *testing.T) {
 		nil)
 	if err == nil {
 		t.Fatalf("should have gotten an error")
+	}
+}
+
+func TestImportWithReplay(t *testing.T) {
+	client := getClient(OptClientLogImports(""))
+
+	// the first iterator for creating the target
+	iterator := &ColumnGenerator{numRows: 10, numColumns: 1000}
+	target := map[uint64][]uint64{}
+	for {
+		rec, err := iterator.NextRecord()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if col, ok := rec.(Column); ok {
+			target[col.RowID] = append(target[col.RowID], col.ColumnID)
+		}
+	}
+	// the second iterator for the actual import
+	iterator = &ColumnGenerator{numRows: 10, numColumns: 1000}
+	field := index.Field("importfield-batchsize")
+	err := client.EnsureField(field)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusChan := make(chan ImportStatusUpdate, 10)
+	err = client.ImportField(field, iterator, OptImportStatusChannel(statusChan), OptImportThreadCount(2), OptImportBatchSize(1000))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// delete index and recreate
+	Reset()
+	field = index.Field("importfield-batchsize")
+	err = client.EnsureField(field)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.logLock.Lock()
+	defer client.logLock.Unlock()
+
+	if client.importLogFile == nil {
+		t.Fatalf("should have a log file")
+	}
+	err = client.importLogFile.Sync()
+	if err != nil {
+		t.Fatalf("syncing log file: %v", err)
+	}
+	name := client.importLogFile.Name()
+	err = client.importLogFile.Close()
+	if err != nil {
+		t.Fatalf("closing import log file: %v", err)
+	}
+
+	f, err := os.Open(name)
+	if err != nil {
+		t.Fatalf("opening import log file: %v", err)
+	}
+	err = client.replayImport(f)
+	if err != nil {
+		t.Fatalf("replaying import: %v", err)
+	}
+
+	for rowID, colIDs := range target {
+		resp, err := client.Query(field.Row(rowID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(colIDs, resp.Result().Row().Columns) {
+			t.Fatalf("%v != %v", colIDs, resp.Result().Row().Columns)
+		}
 	}
 }

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -2469,16 +2469,15 @@ func getMockPathServer(responses map[string]mockResponseItem) *httptest.Server {
 	return httptest.NewServer(handler)
 }
 
-func getClient() *Client {
+func getClient(options ...ClientOption) *Client {
 	var client *Client
 	var err error
 	uri, err := NewURIFromAddress(getPilosaBindAddress())
 	if err != nil {
 		panic(err)
 	}
-	client, err = NewClient(uri,
-		OptClientTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-	)
+	options = append([]ClientOption{OptClientTLSConfig(&tls.Config{InsecureSkipVerify: true})}, options...)
+	client, err = NewClient(uri, options...)
 	if err != nil {
 		panic(err)
 	}

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -1248,22 +1248,21 @@ func TestImportNodeFails(t *testing.T) {
 		Field:      "bar",
 		Shard:      0,
 	}
-	err := client.importNode(uri, importRequest, defaultImportOptions())
+	data, err := proto.Marshal(importRequest)
+	if err != nil {
+		t.Fatalf("marshaling importRequest: %v", err)
+	}
+	err = client.importData(uri, "/index/foo/field/bar/import?clear=false", data)
 	if err == nil {
 		t.Fatalf("importNode should fail when posting to /import fails")
 	}
 }
 
-func TestImportNodeProtobufMarshalFails(t *testing.T) {
+func TestImportPathDataProtobufMarshalFails(t *testing.T) {
 	// even though this function isn't really an integration test,
-	// it needs to access importNode which is not
+	// it needs to access importPathData which is not
 	// available to client_test.go
-	client := getClient()
-	uri, err := NewURIFromAddress("http://does-not-matter.foo.bar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = client.importNode(uri, nil, defaultImportOptions())
+	_, _, err := importPathData(nil, 0, nil, nil)
 	if err == nil {
 		t.Fatalf("Should have failed")
 	}
@@ -1546,17 +1545,6 @@ func TestServerWarning(t *testing.T) {
 	_, err := client.Query(testField.Row(1))
 	if err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestValueCSVImportFailure(t *testing.T) {
-	server := getMockServer(404, []byte("sorry, not found"), -1)
-	defer server.Close()
-	client, _ := NewClient(server.URL)
-	uri := URIFromAddress(server.URL)
-	err := client.importValueNode(uri, nil, defaultImportOptions())
-	if err == nil {
-		t.Fatal("should have failed")
 	}
 }
 

--- a/logimport.go
+++ b/logimport.go
@@ -12,18 +12,18 @@ type importLog struct {
 	Data  []byte
 }
 
-type Encoder interface {
+type encoder interface {
 	Encode(thing interface{}) error
 }
 
-func NewImportLogEncoder(w io.Writer) Encoder {
+func newImportLogEncoder(w io.Writer) encoder {
 	return gob.NewEncoder(w)
 }
 
-type Decoder interface {
+type decoder interface {
 	Decode(thing interface{}) error
 }
 
-func NewImportLogDecoder(r io.Reader) Decoder {
+func newImportLogDecoder(r io.Reader) decoder {
 	return gob.NewDecoder(r)
 }

--- a/logimport.go
+++ b/logimport.go
@@ -1,0 +1,29 @@
+package pilosa
+
+import (
+	"encoding/gob"
+	"io"
+)
+
+type importLog struct {
+	Index string
+	Path  string
+	Shard uint64
+	Data  []byte
+}
+
+type Encoder interface {
+	Encode(thing interface{}) error
+}
+
+func NewImportLogEncoder(w io.Writer) Encoder {
+	return gob.NewEncoder(w)
+}
+
+type Decoder interface {
+	Decode(thing interface{}) error
+}
+
+func NewImportLogDecoder(r io.Reader) Decoder {
+	return gob.NewDecoder(r)
+}

--- a/logimport.go
+++ b/logimport.go
@@ -6,10 +6,11 @@ import (
 )
 
 type importLog struct {
-	Index string
-	Path  string
-	Shard uint64
-	Data  []byte
+	Index     string
+	Path      string
+	Shard     uint64
+	IsRoaring bool
+	Data      []byte
 }
 
 type encoder interface {

--- a/logimport_test.go
+++ b/logimport_test.go
@@ -1,0 +1,141 @@
+package pilosa
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	tests := []importLog{
+		{
+			Index: "go-testindex",
+			Path:  "/index/go-testindex/field/importfield-batchsize/import?clear=false",
+			Shard: 0,
+			Data:  make([]byte, 3918),
+		},
+		{
+			Index: "go-testindex",
+			Path:  "/index/go-testindex/field/importfield-batchsize/import?clear=false",
+			Shard: 0,
+			Data:  make([]byte, 3918),
+		},
+		{
+			Index: "eheh",
+			Path:  "blah",
+			Shard: 9,
+			Data:  []byte("something"),
+		},
+		{
+			Index: "",
+			Path:  "",
+			Shard: 0,
+			Data:  nil,
+		},
+		{
+			Index: "eheh",
+			Path:  "blah",
+			Shard: 10,
+			Data:  []byte("blahaslkdjfeoiwujf"),
+		},
+		{
+			Index: "eheh",
+			Path:  "blah",
+			Shard: 10,
+			Data:  make([]byte, 10000),
+		},
+		{
+			Index: "zoop",
+			Path:  "blah",
+			Shard: 8923734,
+			Data:  []byte("blahaslkdjfeoiwujf"),
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			nl := importLog{
+				Index: test.Index,
+				Path:  test.Path,
+				Shard: test.Shard,
+				Data:  make([]byte, len(test.Data)),
+			}
+			copy(nl.Data, test.Data)
+			buf := &bytes.Buffer{}
+			enc := NewImportLogEncoder(buf)
+			err := enc.Encode(nl)
+			if err != nil {
+				t.Fatalf("writing to buf: %v", err)
+			}
+			dec := NewImportLogDecoder(buf)
+			l2 := &importLog{}
+			err = dec.Decode(l2)
+			if err != nil {
+				t.Fatalf("reading from buf: %v", err)
+			}
+			if l2.Index != test.Index {
+				t.Errorf("indexes not equal:\n%s\n%s", test.Index, l2.Index)
+			}
+			if l2.Path != test.Path {
+				t.Errorf("paths not equal:\n%s\n%s", test.Path, l2.Path)
+			}
+			if l2.Shard != test.Shard {
+				t.Errorf("shards not equal exp: %d got %d", test.Shard, l2.Shard)
+			}
+			if !reflect.DeepEqual(test.Data, l2.Data) {
+				t.Errorf("data not equal \n%v\n%v", test.Data, l2.Data)
+			}
+
+		})
+	}
+	buf, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("getting temp file: %v", err)
+	}
+	enc := NewImportLogEncoder(buf)
+	for _, test := range tests {
+		a := &test
+		err := enc.Encode(a)
+		if err != nil {
+			t.Errorf("encoding to buf: %v", err)
+		}
+	}
+
+	name := buf.Name()
+	err = buf.Close()
+	if err != nil {
+		t.Fatalf("closing temp file: %v", err)
+	}
+
+	buf, err = os.Open(name)
+	if err != nil {
+		t.Fatalf("reopening: %v", err)
+	}
+
+	dec := NewImportLogDecoder(buf)
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			l := &importLog{}
+			err := dec.Decode(l)
+			// err := l.ReadFrom(buf)
+			if err != nil {
+				t.Errorf("reading from buf: %v", err)
+			}
+			if l.Index != test.Index {
+				t.Errorf("indexes not equal:\n%s\n%s", test.Index, l.Index)
+			}
+			if l.Path != test.Path {
+				t.Errorf("paths not equal:\n%s\n%s", test.Path, l.Path)
+			}
+			if l.Shard != test.Shard {
+				t.Errorf("shards not equal exp: %d got %d", test.Shard, l.Shard)
+			}
+			if !reflect.DeepEqual(test.Data, l.Data) {
+				t.Errorf("data not equal \n%v\n%v", test.Data, l.Data)
+			}
+		})
+	}
+}

--- a/logimport_test.go
+++ b/logimport_test.go
@@ -65,12 +65,12 @@ func TestEncodeDecode(t *testing.T) {
 			}
 			copy(nl.Data, test.Data)
 			buf := &bytes.Buffer{}
-			enc := NewImportLogEncoder(buf)
+			enc := newImportLogEncoder(buf)
 			err := enc.Encode(nl)
 			if err != nil {
 				t.Fatalf("writing to buf: %v", err)
 			}
-			dec := NewImportLogDecoder(buf)
+			dec := newImportLogDecoder(buf)
 			l2 := &importLog{}
 			err = dec.Decode(l2)
 			if err != nil {
@@ -95,7 +95,7 @@ func TestEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getting temp file: %v", err)
 	}
-	enc := NewImportLogEncoder(buf)
+	enc := newImportLogEncoder(buf)
 	for _, test := range tests {
 		a := &test
 		err := enc.Encode(a)
@@ -115,7 +115,7 @@ func TestEncodeDecode(t *testing.T) {
 		t.Fatalf("reopening: %v", err)
 	}
 
-	dec := NewImportLogDecoder(buf)
+	dec := newImportLogDecoder(buf)
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			l := &importLog{}


### PR DESCRIPTION
This adds a new client option to enable logging of all import requests. It gob
encodes the index, path, shard, and request body to a file for all requests. The
index and shard are needed so that the code replaying the requests can send them
to a cluster of a different size and still figure out which nodes a request
needs to go to.

I just realized that we're currently writing out every request to every node,
but when we read back in, we're sending each request we read in to every node
that should receive it. This is a bit of a problem if replication is > 1. I'll think about how best to address that, but this is the basic idea.