### PR TITLE
add timestamp to import log

### DIFF
--- a/client.go
+++ b/client.go
@@ -1065,6 +1065,7 @@ func (c *Client) logImport(index, path string, shard uint64, isRoaring bool, dat
 			Path:      path,
 			Shard:     shard,
 			IsRoaring: isRoaring,
+			Timestamp: time.Now().UnixNano(),
 			Data:      data,
 		}
 		// Encode is actually threadsafe (with gob), but the lock above is

--- a/logimport.go
+++ b/logimport.go
@@ -10,6 +10,7 @@ type importLog struct {
 	Path      string
 	Shard     uint64
 	IsRoaring bool
+	Timestamp int64 // Unix Nanoseconds
 	Data      []byte
 }
 


### PR DESCRIPTION
this isn't used right now, but it may be helpful in trying to more
accurately reproduce workloads to know what time each import started.